### PR TITLE
Fix encoding force on a frozen error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Improvement] Allow for disabling the consumer subscription from Web for multi-tenant Web UI usage (#1331)
 - [Improvement] Make sure that states and reports are always dispatched to the partition `0`. This should prevent UI from not fully working when someone accidentally creates more partitions than expected.
 - [Fix] Fix a bug where bootstrapping would create two initial states.
+- [Fix] Fix a case, where errors listener would try to force encoding on a frozen error message.
 
 ## 0.1.3 (2023-02-14)
 - Skip topics creation if web topics already exist (do not raise error)

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,11 @@ plugin 'diffend'
 
 gemspec
 
+gem 'karafka-core', path: '/home/mencio/Software/Karafka/karafka-core'
+
 group :test do
   gem 'byebug'
+  gem 'factory_bot'
   gem 'rspec'
   gem 'simplecov'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,6 @@ plugin 'diffend'
 
 gemspec
 
-gem 'karafka-core', path: '/home/mencio/Software/Karafka/karafka-core'
-
 group :test do
   gem 'byebug'
   gem 'factory_bot'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,32 +4,46 @@ PATH
     karafka-web (0.1.4)
       erubi (~> 1.4)
       karafka (>= 2.0.29, < 3.0.0)
-      karafka-core (>= 2.0.10, < 3.0.0)
+      karafka-core (>= 2.0.12, < 3.0.0)
       roda (~> 3.63)
       tilt (~> 2.0)
+
+PATH
+  remote: /home/mencio/Software/Karafka/karafka-core
+  specs:
+    karafka-core (2.0.12)
+      concurrent-ruby (>= 1.1)
+      karafka-rdkafka (>= 0.12.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.0.4.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     byebug (11.1.3)
     concurrent-ruby (1.2.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     erubi (1.12.0)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
     ffi (1.15.5)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
     karafka (2.0.30)
       karafka-core (>= 2.0.9, < 3.0.0)
       thor (>= 0.20)
       waterdrop (>= 2.4.10, < 3.0.0)
       zeitwerk (~> 2.3)
-    karafka-core (2.0.10)
-      concurrent-ruby (>= 1.1)
-      karafka-rdkafka (>= 0.12)
-    karafka-rdkafka (0.12.0)
+    karafka-rdkafka (0.12.1)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
     mini_portile2 (2.8.1)
+    minitest (5.17.0)
     rack (3.0.4.1)
     rackup (0.2.3)
       rack (>= 3.0.0.beta1)
@@ -58,6 +72,8 @@ GEM
     simplecov_json_formatter (0.1.4)
     thor (1.2.1)
     tilt (2.0.11)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     waterdrop (2.4.10)
       karafka-core (>= 2.0.9, < 3.0.0)
       zeitwerk (~> 2.3)
@@ -70,6 +86,8 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  factory_bot
+  karafka-core!
   karafka-web!
   rackup (~> 0.2)
   rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,16 +4,9 @@ PATH
     karafka-web (0.1.4)
       erubi (~> 1.4)
       karafka (>= 2.0.29, < 3.0.0)
-      karafka-core (>= 2.0.12, < 3.0.0)
+      karafka-core (>= 2.0.11, < 3.0.0)
       roda (~> 3.63)
       tilt (~> 2.0)
-
-PATH
-  remote: /home/mencio/Software/Karafka/karafka-core
-  specs:
-    karafka-core (2.0.12)
-      concurrent-ruby (>= 1.1)
-      karafka-rdkafka (>= 0.12.1)
 
 GEM
   remote: https://rubygems.org/
@@ -33,11 +26,14 @@ GEM
     ffi (1.15.5)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    karafka (2.0.30)
-      karafka-core (>= 2.0.9, < 3.0.0)
+    karafka (2.0.32)
+      karafka-core (>= 2.0.11, < 3.0.0)
       thor (>= 0.20)
       waterdrop (>= 2.4.10, < 3.0.0)
       zeitwerk (~> 2.3)
+    karafka-core (2.0.11)
+      concurrent-ruby (>= 1.1)
+      karafka-rdkafka (>= 0.12.1)
     karafka-rdkafka (0.12.1)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
@@ -49,7 +45,7 @@ GEM
       rack (>= 3.0.0.beta1)
       webrick
     rake (13.0.6)
-    roda (3.64.0)
+    roda (3.65.0)
       rack
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -71,7 +67,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     thor (1.2.1)
-    tilt (2.0.11)
+    tilt (2.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     waterdrop (2.4.10)
@@ -81,13 +77,11 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
-  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
   byebug
   factory_bot
-  karafka-core!
   karafka-web!
   rackup (~> 0.2)
   rspec

--- a/karafka-web.gemspec
+++ b/karafka-web.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'erubi', '~> 1.4'
   spec.add_dependency 'karafka', '>= 2.0.29', '< 3.0.0'
-  spec.add_dependency 'karafka-core', '>= 2.0.10', '< 3.0.0'
+  spec.add_dependency 'karafka-core', '>= 2.0.11', '< 3.0.0'
   spec.add_dependency 'roda', '~> 3.63'
   spec.add_dependency 'tilt', '~> 2.0'
 

--- a/lib/karafka/web/tracking/consumers/listeners/errors.rb
+++ b/lib/karafka/web/tracking/consumers/listeners/errors.rb
@@ -74,7 +74,7 @@ module Karafka
             # @param error [StandardError] error that occurred
             # @return [Array<String, String, String>] array with error name, message and backtrace
             def extract_error_info(error)
-              error_message = error.message.to_s
+              error_message = error.message.to_s.dup
               error_message.force_encoding('utf-8')
               error_message.scrub!
 

--- a/spec/lib/karafka/web/tracking/consumers/listeners/errors_spec.rb
+++ b/spec/lib/karafka/web/tracking/consumers/listeners/errors_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:listener) { described_class.new }
+
+  let(:error) { StandardError.new(-'This is an error') }
+  let(:event) do
+    {
+      type: 'error.occurred',
+      error: error
+    }
+  end
+
+  context 'when error message string is frozen' do
+    it 'expect to process it without problems' do
+      expect { listener.on_error_occurred(event) }.not_to raise_error
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'factory_bot'
+
 coverage = !ENV.key?('GITHUB_WORKFLOW')
 coverage = true if ENV['GITHUB_COVERAGE'] == 'true'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,7 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
 RSpec.configure do |config|
   config.disable_monkey_patching!
   config.order = :random
+  config.include FactoryBot::Syntax::Methods
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
it turns out ppl raise error with frozen messages and we try to force encoding change on them and it fails. We can just dup and go on since it's an error path.

Example:

```ruby
StandardError.new(-'a').message.to_s.force_encoding('utf-8')
```