### PR TITLE
Collect process tags for errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.2.3 (Unreleased)
 - [Improvement] Snapshot current consumer tags upon consumer errors.
 - [Improvement] Optimize exception message extraction from errors.
+- [Improvement] Slightly change error reporting structure (backwards compatible) to collect process tags on errors and to align with other reports.
 
 ## 0.2.2 (2023-02-25)
 - [Fix] Fix status page reference in Pro.

--- a/lib/karafka/web/tracking/consumers/listeners/errors.rb
+++ b/lib/karafka/web/tracking/consumers/listeners/errors.rb
@@ -28,7 +28,8 @@ module Karafka
                   error_message: error_message,
                   backtrace: backtrace,
                   details: details,
-                  occurred_at: float_now
+                  occurred_at: float_now,
+                  process: sampler.to_report[:process].slice(:name, :tags)
                 }
 
                 sampler.counters[:errors] += 1
@@ -54,6 +55,13 @@ module Karafka
             end
 
             private
+
+            # @return [Object] sampler for the metrics
+            # @note We use this sampler to get basic process details that we want to assign
+            #   to the error
+            def consumer_sampler
+              @consumer_sampler ||= ::Karafka::Web.config.tracking.consumers.sampler
+            end
 
             # @param consumer [::Karafka::BaseConsumer]
             # @return [Hash] hash with consumer specific info for details of error

--- a/lib/karafka/web/tracking/reporter.rb
+++ b/lib/karafka/web/tracking/reporter.rb
@@ -44,26 +44,23 @@ module Karafka
 
             @consumer_contract.validate!(consumer_report)
 
+            process_name = consumer_report[:process][:name]
+
             # Report consumers statuses
             messages = [
               {
                 topic: ::Karafka::Web.config.topics.consumers.reports,
                 payload: consumer_report.to_json,
-                key: consumer_report[:process][:name],
+                key: process_name,
                 partition: 0
               }
             ]
 
             # Report errors that occurred (if any)
             messages += consumer_sampler.errors.map do |error|
-              process_name = consumer_report[:process][:name]
-
               {
                 topic: Karafka::Web.config.topics.errors,
-                # Inject process name into the error details for easier tracing
-                payload: error.merge(
-                  process_name: process_name
-                ).to_json,
+                payload: error.to_json,
                 # Always dispatch errors from the same process to the same partition
                 key: process_name
               }


### PR DESCRIPTION
This PR slightly reorganizes error collecting.

- Put process_name in process namespace similar to how it is done with metrics reporting
- Add process tags for errors - to get better visibility
- Build whole error object inside the error listener and not delegate process data injection to the reporter.

This change is backwards compatible so no problems with the UI.
