### PR TITLE
Do not manage declaratively web topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - [Improvement] Paginate topics list in cluster info on every 100 partitions.
 - [Improvement] Provide current page in the pagination.
 - [Improvement] Report usage of Karafka Pro on the status page view.
+- [Fix] Add missing three months limit on errors storage.
+- [Maintenance] Exclude Karafka Web UI topics from declarative topics.
 
 ## 0.2.3 (2023-03-04)
 - [Improvement] Snapshot current consumer tags upon consumer errors.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     karafka-web (0.2.4)
       erubi (~> 1.4)
-      karafka (>= 2.0.33, < 3.0.0)
+      karafka (>= 2.0.35, < 3.0.0)
       karafka-core (>= 2.0.12, < 3.0.0)
       roda (~> 3.63)
       tilt (~> 2.0)
@@ -26,7 +26,7 @@ GEM
     ffi (1.15.5)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    karafka (2.0.33)
+    karafka (2.0.35)
       karafka-core (>= 2.0.12, < 3.0.0)
       thor (>= 0.20)
       waterdrop (>= 2.4.10, < 3.0.0)

--- a/karafka-web.gemspec
+++ b/karafka-web.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.licenses    = %w[LGPL-3.0 Commercial]
 
   spec.add_dependency 'erubi', '~> 1.4'
-  spec.add_dependency 'karafka', '>= 2.0.33', '< 3.0.0'
+  spec.add_dependency 'karafka', '>= 2.0.35', '< 3.0.0'
   spec.add_dependency 'karafka-core', '>= 2.0.12', '< 3.0.0'
   spec.add_dependency 'roda', '~> 3.63'
   spec.add_dependency 'tilt', '~> 2.0'

--- a/lib/karafka/web/installer.rb
+++ b/lib/karafka/web/installer.rb
@@ -45,6 +45,7 @@ module Karafka
           consumer_group ::Karafka::Web.config.processing.consumer_group do
             # Topic we listen on to materialize the states
             topic ::Karafka::Web.config.topics.consumers.reports do
+              config(active: false)
               active ::Karafka::Web.config.processing.active
               # Since we materialize state in intervals, we can poll for half of this time without
               # impacting the reporting responsiveness
@@ -58,11 +59,13 @@ module Karafka
             # We define those two here without consumption, so Web understands how to deserialize
             # them when used / viewed
             topic ::Karafka::Web.config.topics.consumers.states do
+              config(active: false)
               active false
               deserializer web_deserializer
             end
 
             topic ::Karafka::Web.config.topics.errors do
+              config(active: false)
               active false
               deserializer web_deserializer
             end
@@ -126,7 +129,9 @@ module Karafka
           ::Karafka::Admin.create_topic(
             errors_topic,
             1,
-            replication_factor
+            replication_factor,
+            # Remove really old errors (older than 3 months just to preserve space)
+            { 'retention.ms': 3 * 31 * 24 * 60 * 60 * 1_000 }
           )
         end
       end


### PR DESCRIPTION
This PR ensures that the web topics are not managed declaratively (for now) and adds missing time limit on errors storage.