### PR TITLE
Reporting remarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Karafka Web changelog
 
+## 0.4.1 (Unreleased)
+- [Improvement] Replace the "x time ago" in the code explorer with an exact date (`2023-04-12 10:16:48.596 +0200 `).
+- [Improvement] When hovering over a message timestamp, a label with raw numeric timestamp will be presented.
+- [Improvement] Do not skip reporting on partitions subscribed that never received any messages.
+- [Fix] Skip reporting data on subscriptions that were revoked and not only stopped by us.
+
 ## 0.4.0 (2023-04-07)
 - [Improvement] Include active jobs and active partitions subscriptions count in the per-process tab navigation.
 - [Improvement] Include subscription groups names in the per-process subscriptions view.

--- a/lib/karafka/web/tracking/consumers/listeners/statistics.rb
+++ b/lib/karafka/web/tracking/consumers/listeners/statistics.rb
@@ -87,12 +87,13 @@ module Karafka
             def partition_reportable?(pt_id, pt_stats)
               return false if pt_id == -1
 
-              # Skip until lag info is available
-              return false if pt_stats['consumer_lag'] == -1
-
               # Collect information only about what we are subscribed to and what we fetch or
-              # work in any way. Stopped means, we no longer work with it
+              # work in any way. Stopped means, we stopped working with it
               return false if pt_stats['fetch_state'] == 'stopped'
+
+              # Return if we no longer fetch this partition in a particular process. None means
+              # that we no longer have this subscription assigned and we do not fetch
+              return false if pt_stats['fetch_state'] == 'none'
 
               true
             end

--- a/lib/karafka/web/ui/helpers/application_helper.rb
+++ b/lib/karafka/web/ui/helpers/application_helper.rb
@@ -46,10 +46,6 @@ module Karafka
             render "#{scope}/_breadcrumbs"
           end
 
-          def time_to_string(time)
-
-          end
-
           # Takes a status and recommends background style color
           #
           # @param status [String] status

--- a/lib/karafka/web/ui/helpers/application_helper.rb
+++ b/lib/karafka/web/ui/helpers/application_helper.rb
@@ -46,6 +46,10 @@ module Karafka
             render "#{scope}/_breadcrumbs"
           end
 
+          def time_to_string(time)
+
+          end
+
           # Takes a status and recommends background style color
           #
           # @param status [String] status
@@ -125,8 +129,16 @@ module Karafka
           # @param time [Float] UTC time float
           # @return [String] relative time tag for timeago.js
           def relative_time(time)
-            stamp = Time.at(time).getutc.iso8601
+            stamp = Time.at(time).getutc.iso8601(3)
             %(<time class="ltr" dir="ltr" title="#{stamp}" datetime="#{stamp}">#{time}</time>)
+          end
+
+          # @param time [Time] time object we want to present with detailed ms label
+          # @return [String] span tag with raw timestamp as a title and time as a value
+          def labeled_time(time)
+            stamp = (time.to_f * 1000).to_i
+
+            %(<span title="#{stamp}">#{time}</span>)
           end
 
           # Returns the view title html code

--- a/lib/karafka/web/ui/pro/views/consumers/consumer/_partition.erb
+++ b/lib/karafka/web/ui/pro/views/consumers/consumer/_partition.erb
@@ -20,7 +20,13 @@
     </span>
   </td>
   <td>
-    <%= partition.committed_offset %>
+    <% if partition.committed_offset.to_i < 0 %>
+      <span class="badge bg-secondary" title="Not available until first offset commit">
+        N/A
+      </span>
+    <% else %>
+      <%= partition.committed_offset %>
+    <% end %>
   </td>
   <td>
     <% if partition.stored_offset.to_i < 0 %>

--- a/lib/karafka/web/ui/pro/views/explorer/_detail.erb
+++ b/lib/karafka/web/ui/pro/views/explorer/_detail.erb
@@ -9,6 +9,15 @@
       </td>
    </tr>
   <% end %>
+<% elsif v.is_a?(Time) %>
+  <tr>
+    <td>
+      <%= k %>
+    </td>
+    <td>
+      <%== labeled_time(v) %>
+    </td>
+  </tr>
 <% else %>
   <tr>
     <td>

--- a/lib/karafka/web/ui/pro/views/explorer/_message.erb
+++ b/lib/karafka/web/ui/pro/views/explorer/_message.erb
@@ -13,7 +13,7 @@
       <%= message.offset %>
     </td>
     <td>
-      <%== relative_time message.timestamp %>
+      <%== labeled_time(message.timestamp) %>
     </td>
     <td>
       <%= message.key %>


### PR DESCRIPTION
This PR tackles few things:

- [Improvement] Replace the "x time ago" in the code explorer with an exact date (`2023-04-12 10:16:48.596 +0200 `).
- [Improvement] When hovering over a message timestamp, a label with raw numeric timestamp will be presented.
- [Improvement] Do not skip reporting on partitions subscribed that never received any messages.
- [Fix] Skip reporting data on subscriptions that were revoked and not only stopped by us.

close https://github.com/karafka/karafka-web/issues/50