### PR TITLE
Fix extensive thread interrupts on HPET clocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - [Improvement] Do not include page when page is 1 in the url.
 - [Refactor] Reorganize pagination engine to support offset based pagination.
 
+## 0.6.2 (2023-07-22)
+- [Fix] Fix extensive CPU usage when using HPET clock instead of TSC due to interrupt frequency.
+
 ## 0.6.1 (2023-06-25)
 - [Improvement] Include the karafka-web version in the status page tags.
 - [Improvement] Report `karafka-web` version that is running in particular processes.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka-web (0.6.1)
+    karafka-web (0.6.2)
       erubi (~> 1.4)
       karafka (>= 2.1.4, < 3.0.0)
       karafka-core (>= 2.0.13, < 3.0.0)

--- a/lib/karafka/web/tracking/consumers/reporter.rb
+++ b/lib/karafka/web/tracking/consumers/reporter.rb
@@ -93,12 +93,14 @@ module Karafka
           def call
             @running = true
 
+            # We won't track more often anyhow but want to try frequently not to miss a window
+            # We need to convert the sleep interval into seconds for sleep
+            sleep_time = ::Karafka::Web.config.tracking.interval.to_f / 1_000 / 10
+
             loop do
               report
 
-              # We won't track more often anyhow but want to try frequently not to miss a window
-              # We need to convert the sleep interval into seconds for sleep
-              sleep(::Karafka::Web.config.tracking.interval / 1_000 / 10)
+              sleep(sleep_time)
             end
           end
 

--- a/lib/karafka/web/version.rb
+++ b/lib/karafka/web/version.rb
@@ -3,6 +3,6 @@
 module Karafka
   module Web
     # Current gem version
-    VERSION = '0.6.1'
+    VERSION = '0.6.2'
   end
 end


### PR DESCRIPTION
This affects ANY clock type but on HPET it is visible the most.