### PR TITLE
Use cluster data for default replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - [Improvement] Introduce cookie based sessions management for future usage.
 - [Improvement] Introduce config validation.
 - [Improvement] Provide flash messages support.
+- [Improvement] Use replication factor of two by default (if not overridden) for Web UI topics when there is more than one broker.
 - [Fix] Return 402 status instead of 500 on Pro features that are not available in OSS.
 - [Fix] Fix a case where errors would not be visible without Rails due to the `String#first` usage.
 - [Fix] Fix a case where live-poll would be disabled but would still update data.

--- a/lib/karafka/web/cli.rb
+++ b/lib/karafka/web/cli.rb
@@ -12,20 +12,24 @@ module Karafka
       method_option(
         :replication_factor,
         desc: 'Replication factor for created topics',
-        default: 1,
+        default: false,
+        check_default_type: false,
         type: :numeric
       )
       # Installs Karafka Web. Creates all needed topics, populates the data and adds the needed
       # code to `karafka.rb`.
       def install
-        Karafka::Web::Installer.new.install(replication_factor: options[:replication_factor])
+        Karafka::Web::Installer.new.install(
+          replication_factor: compute_replication_factor(options[:replication_factor])
+        )
       end
 
       desc 'migrate', 'Creates necessary topics if not present and populates state data'
       method_option(
         :replication_factor,
         desc: 'Replication factor for created topics',
-        default: 1,
+        default: false,
+        check_default_type: false,
         type: :numeric
       )
       # Creates new topics (if any) and populates missing data.
@@ -37,26 +41,43 @@ module Karafka
       #   2. When upgrading Web-UI in-between versions that would require extra topics and/or extra
       #      states populated.
       def migrate
-        Karafka::Web::Installer.new.migrate(replication_factor: options[:replication_factor])
+        Karafka::Web::Installer.new.migrate(
+          replication_factor: compute_replication_factor(options[:replication_factor])
+        )
       end
 
       desc 'reset', 'Resets the Web UI by removing all the Web topics and creating them again'
       method_option(
         :replication_factor,
         desc: 'Replication factor for created topics',
-        default: 1,
+        default: false,
+        check_default_type: false,
         type: :numeric
       )
       # Resets Karafka Web. Removes the topics, creates them again and populates the initial state
       # again. This is useful in case the Web-UI metrics or anything else got corrupted.
       def reset
-        Karafka::Web::Installer.new.reset(replication_factor: options[:replication_factor])
+        Karafka::Web::Installer.new.reset(
+          replication_factor: compute_replication_factor(options[:replication_factor])
+        )
       end
 
       desc 'uninstall', 'Removes all the Web UI topics and the enabled code'
       # Uninstalls Karafka Web
       def uninstall
         Karafka::Web::Installer.new.uninstall
+      end
+
+      private
+
+      # Takes the CLI user provided replication factor but if not present, uses the brokers count
+      # to decide. For non-dev clusters (with one broker) we usually want to have replication of
+      # two, just to have some redundancy.
+      # @param cli_replication_factor [Integer, false] user requested replication factor or false
+      #   if we are supposed to compute the factor automatically
+      # @return [Integer] replication factor for Karafka Web UI topics
+      def compute_replication_factor(cli_replication_factor)
+        cli_replication_factor || Ui::Models::ClusterInfo.fetch.brokers.size > 1 ? 2 : 1
       end
     end
   end


### PR DESCRIPTION
There were several cases where people would not set up prod with decent replication. This PR changes that by using cluster awareness to decide if use no replication or replication of two