### PR TITLE
Restore errors for OSS in dashboard charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka Web changelog
 
+## 0.7.2 (Unreleased) 
+- [Improvement] Display hidden by accident errors for OSS metrics.
+
 ## 0.7.1 (2023-09-15)
 - [Improvement] Limit number of partitions listed on the Consumers view if they exceed 10 to improve readability and indicate, that there are more.
 - [Improvement] Make sure, that small messages size (less than 100 bytes) is correctly displayed.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka-web (0.7.1)
+    karafka-web (0.7.2)
       erubi (~> 1.4)
       karafka (>= 2.2.3, < 3.0.0)
       karafka-core (>= 2.2.2, < 3.0.0)

--- a/lib/karafka/web/ui/views/dashboard/index.erb
+++ b/lib/karafka/web/ui/views/dashboard/index.erb
@@ -29,7 +29,7 @@
 
         <div class="tab-content">
           <div class="tab-pane show active" id="messages" role="tabpanel">
-            <% data = @aggregated_charts.with(:messages) %>
+            <% data = @aggregated_charts.with(:messages, :errors) %>
             <%== partial 'shared/chart', locals: { data: data, id: 'messages' } %>
           </div>
 

--- a/lib/karafka/web/version.rb
+++ b/lib/karafka/web/version.rb
@@ -3,6 +3,6 @@
 module Karafka
   module Web
     # Current gem version
-    VERSION = '0.7.1'
+    VERSION = '0.7.2'
   end
 end


### PR DESCRIPTION
I removed it for testing and forgot to restore:

close https://github.com/karafka/karafka-web/issues/126

![image](https://github.com/karafka/karafka-web/assets/392754/79d0f976-df82-4697-9f06-3575220fa99a)
