### PR TITLE
Fix extensive data polling and deserialization on expired processes states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - [Improvement] Display hidden by accident errors for OSS metrics.
 - [Improvement] Use a five second cache for non-production environments to improve dev experience.
 - [Improvement] Limit number of partitions listed on the Consumers view if they exceed 10 to improve readability and indicate, that there are more in OSS similar to Pro.
+- [Improvement] Squash processes reports based on the key instead of payload skipping deserialization for duplicated reports.
+- [Fix] Extensive data-poll on processes despite no processes being available.
 
 ## 0.7.1 (2023-09-15)
 - [Improvement] Limit number of partitions listed on the Consumers view if they exceed 10 to improve readability and indicate, that there are more in Pro.

--- a/lib/karafka/web/ui/models/processes.rb
+++ b/lib/karafka/web/ui/models/processes.rb
@@ -18,9 +18,10 @@ module Karafka
             # @param state [State] current system state from which we can get processes metadata
             # @return [Array<Process>]
             def active(state)
-              processes = fetch_reports(state)
+              messages = fetch_reports(state)
+              messages = squash_processes_data(messages)
+              processes = messages.map(&:payload)
               evict_expired_processes(processes)
-              processes = squash_processes_data(processes)
               processes = sort_processes(processes)
 
               processes.map { |process_hash| Process.new(process_hash) }
@@ -32,7 +33,13 @@ module Karafka
             # @param state [State]
             # @return [Array<Hash>] array with deserialized processes reports
             def fetch_reports(state)
-              offsets = state[:processes]
+              processes = state[:processes]
+
+              # Short track when no processes not to run a read when nothing will be given
+              # This allows us to handle a case where we would load 10k of reports for nothing
+              return [] if processes.empty?
+
+              offsets = processes
                         .values
                         .map { |process| process[:offset] }
                         .sort
@@ -46,7 +53,7 @@ module Karafka
                 # was bypassed by state changes in the processes
                 10_000,
                 offsets.first || -1
-              ).map(&:payload)
+              )
             end
 
             # Collapses processes data and only keeps the most recent report for give process
@@ -55,7 +62,7 @@ module Karafka
             def squash_processes_data(processes)
               processes
                 .reverse
-                .uniq { |consumer| consumer[:process][:name] }
+                .uniq { |message| message.key }
                 .reverse
             end
 

--- a/lib/karafka/web/ui/models/processes.rb
+++ b/lib/karafka/web/ui/models/processes.rb
@@ -62,7 +62,7 @@ module Karafka
             def squash_processes_data(processes)
               processes
                 .reverse
-                .uniq { |message| message.key }
+                .uniq(&:key)
                 .reverse
             end
 

--- a/spec/lib/karafka/web/ui/controllers/consumers_spec.rb
+++ b/spec/lib/karafka/web/ui/controllers/consumers_spec.rb
@@ -60,8 +60,6 @@ RSpec.describe_current do
       data = JSON.parse(fixtures_file('consumers_state.json'))
       base_report = JSON.parse(fixtures_file('consumer_report.json'))
 
-      reports = []
-
       100.times do |i|
         name = "shinra:#{i}:#{i}"
 

--- a/spec/lib/karafka/web/ui/controllers/consumers_spec.rb
+++ b/spec/lib/karafka/web/ui/controllers/consumers_spec.rb
@@ -73,11 +73,10 @@ RSpec.describe_current do
         report = base_report.dup
         report['process']['name'] = name
 
-        reports << report.to_json
+        produce(reports_topic, report.to_json, key: name)
       end
 
       produce(states_topic, data.to_json)
-      produce_many(reports_topic, reports)
     end
 
     context 'when we visit first page' do

--- a/spec/lib/karafka/web/ui/controllers/jobs_spec.rb
+++ b/spec/lib/karafka/web/ui/controllers/jobs_spec.rb
@@ -44,8 +44,6 @@ RSpec.describe_current do
         data = JSON.parse(fixtures_file('consumers_state.json'))
         base_report = JSON.parse(fixtures_file('consumer_report.json'))
 
-        reports = []
-
         100.times do |i|
           name = "shinra:#{i}:#{i}"
 
@@ -57,11 +55,10 @@ RSpec.describe_current do
           report = base_report.dup
           report['process']['name'] = name
 
-          reports << report.to_json
+          produce(reports_topic, report.to_json, key: name)
         end
 
         produce(states_topic, data.to_json)
-        produce_many(reports_topic, reports)
       end
 
       context 'when visiting first page' do

--- a/spec/lib/karafka/web/ui/pro/controllers/consumers_spec.rb
+++ b/spec/lib/karafka/web/ui/pro/controllers/consumers_spec.rb
@@ -61,8 +61,6 @@ RSpec.describe_current do
         data = JSON.parse(fixtures_file('consumers_state.json'))
         base_report = JSON.parse(fixtures_file('consumer_report.json'))
 
-        reports = []
-
         100.times do |i|
           name = "shinra:#{i}:#{i}"
 
@@ -74,11 +72,10 @@ RSpec.describe_current do
           report = base_report.dup
           report['process']['name'] = name
 
-          reports << report.to_json
+          produce(reports_topic, report.to_json, key: name)
         end
 
         produce(states_topic, data.to_json)
-        produce_many(reports_topic, reports)
       end
 
       context 'when we visit first page' do

--- a/spec/lib/karafka/web/ui/pro/controllers/jobs_spec.rb
+++ b/spec/lib/karafka/web/ui/pro/controllers/jobs_spec.rb
@@ -44,8 +44,6 @@ RSpec.describe_current do
         data = JSON.parse(fixtures_file('consumers_state.json'))
         base_report = JSON.parse(fixtures_file('consumer_report.json'))
 
-        reports = []
-
         100.times do |i|
           name = "shinra:#{i}:#{i}"
 
@@ -57,11 +55,10 @@ RSpec.describe_current do
           report = base_report.dup
           report['process']['name'] = name
 
-          reports << report.to_json
+          produce(reports_topic, report.to_json, key: name)
         end
 
         produce(states_topic, data.to_json)
-        produce_many(reports_topic, reports)
       end
 
       context 'when visiting first page' do


### PR DESCRIPTION
This PR changes how we fetch process details. Because since web 0.5.0 we publish process name as the key alongside payload, we can use it to uniquely squash data. This prevents us from extensive parsing of JSONs. We can also early skip when no processes saving us request to Kafka

close https://github.com/karafka/karafka-web/issues/131