### PR TITLE
Replace Docker and use Bundler cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,15 @@ jobs:
         run: |
           docker-compose up -d
 
+      - name: Wait for Kafka
+        run: |
+          bundle exec bin/wait_for_kafka
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}
+          bundler-cache: true
 
       - name: Install latest bundler
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,6 @@ jobs:
         run: |
           docker-compose up -d
 
-      - name: Wait for Kafka
-        run: |
-          bundle exec bin/wait_for_kafka
-
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -55,6 +51,10 @@ jobs:
         run: |
           bundle config set without development
           bundle install --jobs 4 --retry 3
+
+      - name: Wait for Kafka
+        run: |
+          bundle exec bin/wait_for_kafka
 
       - name: Run all tests
         env:

--- a/bin/wait_for_kafka
+++ b/bin/wait_for_kafka
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+# Waits for Kafka to be ready
+# Useful in CI where Kafka needs to be fully started before we run any tests
+
+require 'karafka'
+
+Karafka::App.setup do |config|
+  config.kafka[:'bootstrap.servers'] = '127.0.0.1:9092'
+end
+
+60.times do
+  begin
+    # Stop if we can connect to the cluster and get info
+    exit if Karafka::Admin.cluster_info
+  rescue Rdkafka::RdkafkaError
+    puts "Kafka not available, retrying..."
+    sleep(1)
+  end
+end
+
+puts 'Kafka not available!'
+
+exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,24 @@
 version: '2'
+
 services:
   zookeeper:
-    container_name: karafka_web_21_zookeeper
-    image: wurstmeister/zookeeper
-    restart: on-failure
-    ports:
-      - '2181:2181'
+    container_name: karafka_web_zookeeper
+    image: confluentinc/cp-zookeeper:7.5.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 100
 
   kafka:
-    container_name: karafka_web_21_kafka
-    image: wurstmeister/kafka
+    container_name: karafka_web_kafka
+    image: confluentinc/cp-kafka:7.5.0
+    depends_on:
+      - zookeeper
     ports:
-      - '9092:9092'
+      - 9092:9092
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: localhost
-      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    restart: on-failure
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1


### PR DESCRIPTION
This PR replaces the docker setup with confluent kafka + adds bundler cache as we don't care here about recompiling and we do not do intermediate bundling.

We're removing one spec because bundler-cache caches zstd so we don't have how to check it. We check it in Karafka nonetheless the same way.