### PR TITLE
v0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Karafka Web changelog
 
-## 0.7.7 (Unreleased)
+## 0.7.7 (2023-10-20)
 - [Fix] Remove `thor` as a CLI engine due to breaking changes.
 
 ## 0.7.6 (2023-10-10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka-web (0.7.6)
+    karafka-web (0.7.7)
       erubi (~> 1.4)
       karafka (>= 2.2.8.beta1, < 3.0.0)
       karafka-core (>= 2.2.2, < 3.0.0)

--- a/lib/karafka/web/version.rb
+++ b/lib/karafka/web/version.rb
@@ -3,6 +3,6 @@
 module Karafka
   module Web
     # Current gem version
-    VERSION = '0.7.6'
+    VERSION = '0.7.7'
   end
 end


### PR DESCRIPTION
the dependency on beta1 karafka is on purpose. We need to make sure karafka works with web and in order to run all specs in karafka we need to have web released.