### PR TITLE
Provide ability to use karafka-web dedicated producer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [Fix] Make sure that the `recent` displays the most recent non-compacted, non-system message.
 - [Fix] Improve the `recent` message display to compensate for aborted transactions.
 - [Fix] Fix `ReferenceError: response is not defined` that occurs when Web UI returns refresh non 200.
+- [Change] Rely on `karafka-core` `>=` `2.2.4` to support lazy loaded custom web producer.
 
 ## 0.7.7 (2023-10-20)
 - [Fix] Remove `thor` as a CLI engine due to breaking changes.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     karafka-web (0.7.8)
       erubi (~> 1.4)
       karafka (>= 2.2.9, < 3.0.0)
-      karafka-core (>= 2.2.2, < 3.0.0)
+      karafka-core (>= 2.2.4, < 3.0.0)
       roda (~> 3.68, >= 3.69)
       tilt (~> 2.0)
 
@@ -40,7 +40,7 @@ GEM
       karafka-core (>= 2.2.2, < 2.3.0)
       waterdrop (>= 2.6.10, < 3.0.0)
       zeitwerk (~> 2.3)
-    karafka-core (2.2.3)
+    karafka-core (2.2.4)
       concurrent-ruby (>= 1.1)
       karafka-rdkafka (>= 0.13.6, < 0.14.0)
     karafka-rdkafka (0.13.6)

--- a/karafka-web.gemspec
+++ b/karafka-web.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'erubi', '~> 1.4'
   spec.add_dependency 'karafka', '>= 2.2.9', '< 3.0.0'
-  spec.add_dependency 'karafka-core', '>= 2.2.2', '< 3.0.0'
+  spec.add_dependency 'karafka-core', '>= 2.2.4', '< 3.0.0'
   spec.add_dependency 'roda', '~> 3.68', '>= 3.69'
   spec.add_dependency 'tilt', '~> 2.0'
 

--- a/lib/karafka/web.rb
+++ b/lib/karafka/web.rb
@@ -13,6 +13,12 @@ module Karafka
   # Karafka Web UI + Karafka web monitoring
   module Web
     class << self
+      # @return [WaterDrop::Producer, nil] waterdrop messages producer or nil if not yet fully
+      #   initialized. It may not be fully initialized until the configuration is done
+      def producer
+        @producer ||= Web.config.producer
+      end
+
       # @return [String] root path of this gem
       def gem_root
         Pathname.new(File.expand_path('../..', __dir__))

--- a/lib/karafka/web/management/create_initial_states.rb
+++ b/lib/karafka/web/management/create_initial_states.rb
@@ -55,7 +55,7 @@ module Karafka
             exists('consumers state')
           else
             creating('consumers state')
-            ::Karafka.producer.produce_sync(
+            ::Karafka::Web.producer.produce_sync(
               topic: Karafka::Web.config.topics.consumers.states,
               key: Karafka::Web.config.topics.consumers.states,
               payload: DEFAULT_STATE.to_json
@@ -67,7 +67,7 @@ module Karafka
             exists('consumers metrics')
           else
             creating('consumers metrics')
-            ::Karafka.producer.produce_sync(
+            ::Karafka::Web.producer.produce_sync(
               topic: Karafka::Web.config.topics.consumers.metrics,
               key: Karafka::Web.config.topics.consumers.metrics,
               payload: DEFAULT_METRICS.merge(dispatched_at: Time.now.to_f).to_json

--- a/lib/karafka/web/processing/consumer.rb
+++ b/lib/karafka/web/processing/consumer.rb
@@ -114,7 +114,7 @@ module Karafka
         def flush
           @flushed_at = monotonic_now
 
-          producer.produce_many_async(
+          ::Karafka::Web.producer.produce_many_async(
             [
               {
                 topic: Karafka::Web.config.topics.consumers.states,

--- a/lib/karafka/web/tracking/consumers/reporter.rb
+++ b/lib/karafka/web/tracking/consumers/reporter.rb
@@ -135,9 +135,9 @@ module Karafka
           #   slowdown any processing.
           def produce(messages)
             if messages.count >= PRODUCE_SYNC_THRESHOLD
-              ::Karafka.producer.produce_many_sync(messages)
+              ::Karafka::Web.producer.produce_many_sync(messages)
             else
-              ::Karafka.producer.produce_many_async(messages)
+              ::Karafka::Web.producer.produce_many_async(messages)
             end
           # Since we run this in a background thread, there may be a case upon shutdown, where the
           # producer is closed right before a potential dispatch. It is not worth dealing with this

--- a/lib/karafka/web/tracking/producers/reporter.rb
+++ b/lib/karafka/web/tracking/producers/reporter.rb
@@ -83,9 +83,9 @@ module Karafka
           #   slowdown any processing.
           def produce(messages)
             if messages.count >= PRODUCE_SYNC_THRESHOLD
-              ::Karafka.producer.produce_many_sync(messages)
+              ::Karafka::Web.producer.produce_many_sync(messages)
             else
-              ::Karafka.producer.produce_many_async(messages)
+              ::Karafka::Web.producer.produce_many_async(messages)
             end
           # Since we run this in a background thread, there may be a case upon shutdown, where the
           # producer is closed right before a potential dispatch. It is not worth dealing with this

--- a/lib/karafka/web/tracking/reporter.rb
+++ b/lib/karafka/web/tracking/reporter.rb
@@ -14,8 +14,8 @@ module Karafka
         #
         # @return [Boolean]
         def active?
-          return false unless ::Karafka::App.producer
-          return false unless ::Karafka::App.producer.status.active?
+          return false unless ::Karafka::Web.producer
+          return false unless ::Karafka::Web.producer.status.active?
 
           true
         end

--- a/lib/karafka/web/ui/pro/controllers/messages.rb
+++ b/lib/karafka/web/ui/pro/controllers/messages.rb
@@ -28,7 +28,7 @@ module Karafka
             def republish(topic_id, partition_id, offset)
               message = Ui::Models::Message.find(topic_id, partition_id, offset)
 
-              delivery = ::Karafka.producer.produce_sync(
+              delivery = ::Karafka::Web.producer.produce_sync(
                 topic: topic_id,
                 partition: partition_id,
                 payload: message.raw_payload,

--- a/spec/lib/karafka/web/tracking/producers/reporter_spec.rb
+++ b/spec/lib/karafka/web/tracking/producers/reporter_spec.rb
@@ -21,18 +21,18 @@ RSpec.describe_current do
 
   before do
     Karafka::Web.config.topics.errors = errors_topic
-    allow(Karafka).to receive(:producer).and_return(producer)
+    allow(Karafka::Web).to receive(:producer).and_return(producer)
     allow(producer.status).to receive(:active?).and_return(true)
-    allow(Karafka.producer).to receive(:produce_many_sync)
-    allow(Karafka.producer).to receive(:produce_many_async)
+    allow(Karafka::Web.producer).to receive(:produce_many_sync)
+    allow(Karafka::Web.producer).to receive(:produce_many_async)
   end
 
   context 'when there is nothing to report' do
     it 'expect not to dispatch any messages' do
       reporter.report
 
-      expect(::Karafka.producer).not_to have_received(:produce_many_sync)
-      expect(::Karafka.producer).not_to have_received(:produce_many_async)
+      expect(::Karafka::Web.producer).not_to have_received(:produce_many_sync)
+      expect(::Karafka::Web.producer).not_to have_received(:produce_many_async)
     end
   end
 
@@ -45,8 +45,8 @@ RSpec.describe_current do
     it 'expect not to dispatch any messages yet' do
       reporter.report
 
-      expect(::Karafka.producer).not_to have_received(:produce_many_sync)
-      expect(::Karafka.producer).not_to have_received(:produce_many_async)
+      expect(::Karafka::Web.producer).not_to have_received(:produce_many_sync)
+      expect(::Karafka::Web.producer).not_to have_received(:produce_many_async)
     end
   end
 
@@ -103,13 +103,13 @@ RSpec.describe_current do
 
   describe '#active?' do
     context 'when producer is not yet created' do
-      before { allow(Karafka).to receive(:producer).and_return(nil) }
+      before { allow(Karafka::Web).to receive(:producer).and_return(nil) }
 
       it { expect(reporter.active?).to eq(false) }
     end
 
     context 'when producer is not active' do
-      before { allow(Karafka.producer.status).to receive(:active?).and_return(false) }
+      before { allow(Karafka::Web.producer.status).to receive(:active?).and_return(false) }
 
       it { expect(reporter.active?).to eq(false) }
     end

--- a/spec/lib/karafka/web/tracking/reporter_spec.rb
+++ b/spec/lib/karafka/web/tracking/reporter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe_current do
 
   describe '#active?' do
     context 'when producer is not yet created' do
-      before { allow(Karafka).to receive(:producer).and_return(nil) }
+      before { allow(Karafka::Web).to receive(:producer).and_return(nil) }
 
       it { expect(reporter.active?).to eq(false) }
     end


### PR DESCRIPTION
close https://github.com/karafka/karafka-web/issues/194

This allows for better resources utilization and improved reporting when using web-ui with transactional consumers as the web reporting dedicated consumer can be configured independently.
