### PR TITLE
Fix invalid reporting and display of the LSO graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka Web changelog
 
+## 0.7.10 (Unreleased)
+- [Fix] Max LSO chart does not work as expected (#201)
+
 ## 0.7.9 (2023-10-25)
 - [Enhancement] Allow for `Karafka::Web.producer` reconfiguration from the default (`Karafka.producer`).
 - [Change] Rely on `karafka-core` `>=` `2.2.4` to support lazy loaded custom web producer.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka-web (0.7.9)
+    karafka-web (0.7.10)
       erubi (~> 1.4)
       karafka (>= 2.2.9, < 3.0.0)
       karafka-core (>= 2.2.4, < 3.0.0)

--- a/lib/karafka/web/processing/consumers/aggregators/metrics.rb
+++ b/lib/karafka/web/processing/consumers/aggregators/metrics.rb
@@ -107,9 +107,18 @@ module Karafka
 
                 # Last stable offsets freeze durations - we pick the max freeze to indicate
                 # the longest open transaction that potentially may be hanging
-                ls_offsets_fd = partitions_data
-                                .map { |p_details| p_details.fetch(:ls_offset_fd, 0) }
-                                .reject(&:negative?)
+                # We select only those partitions for which LSO != HO as in any other case this
+                # just means we've reached the end of data and ls may freeze because there is no
+                # more data flowing. Such cases should not be reported as ls offset freezes because
+                # there is no more data to be processed and can grow until more data is present
+                # this does not indicate "bad" freezing that we are interested in
+                ls_offsets_fds = partitions_data.map do |p_details|
+                  next if p_details.fetch(:ls_offset, 0) == p_details.fetch(:hi_offset, 0)
+
+                  ls_offset_fd = p_details.fetch(:ls_offset_fd, 0)
+
+                  ls_offset_fd.negative? ? nil : ls_offset_fd
+                end
 
                 cgs[group_name] ||= {}
                 cgs[group_name][topic_name] = {
@@ -119,7 +128,7 @@ module Karafka
                   # Take max last stable offset duration without any change. This can
                   # indicate a hanging transaction, because the offset will not move forward
                   # and will stay with a growing freeze duration when stuck
-                  ls_offset_fd: ls_offsets_fd.max || 0
+                  ls_offset_fd: ls_offsets_fds.compact.max || 0
                 }
               end
 

--- a/lib/karafka/web/ui/models/metrics/charts/topics.rb
+++ b/lib/karafka/web/ui/models/metrics/charts/topics.rb
@@ -76,20 +76,11 @@ module Karafka
                   topic_without_cg = topic.split('[').first
 
                   metrics.each do |current|
-                    ls_offset = current.last[:ls_offset] || 0
                     ls_offset_fd = current.last[:ls_offset_fd] || 0
-                    hi_offset = current.last[:hi_offset] || 0
 
                     # We convert this to seconds from milliseconds due to our Web UI precision
                     # Reporting is in ms for consistency
                     normalized_fd = (ls_offset_fd / 1_000).round
-                    # In case ls_offset and hi_offset are the same, it means we're reached eof
-                    # and we just don't have more data. In cases like this, LSO freeze duration
-                    # will grow because LSO will remain unchanged, but it does not mean it is
-                    # frozen. It means there is just no more data in the topic partition
-                    # This means we need to nullify this case, otherwise it would report, that
-                    # lso is hanging.
-                    normalized_fd = 0 if ls_offset == hi_offset
 
                     topics[topic_without_cg][current.first] << normalized_fd
                   end

--- a/lib/karafka/web/version.rb
+++ b/lib/karafka/web/version.rb
@@ -3,6 +3,6 @@
 module Karafka
   module Web
     # Current gem version
-    VERSION = '0.7.9'
+    VERSION = '0.7.10'
   end
 end


### PR DESCRIPTION
Per partition Health was reporting correctly, the issue was just with the graph aggregation.

![image](https://github.com/karafka/karafka-web/assets/392754/a924d188-f5c2-4086-aff1-18a82eb357ce)


close https://github.com/karafka/karafka-web/issues/201