### PR TITLE
Pending jobs visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Web changelog
 
 ## 0.8.0 (Unreleased)
+- **[Feature]** Introduce pending jobs visibility alongside of running jobs both in total and per process.
 - **[Feature]** Introduce states migrations for seamless upgrades.
 - **[Feature]** Introduce "Data transfers" chart with data received and data sent to the cluster.
 - **[Feature]** Introduce ability to download raw payloads.
@@ -14,6 +15,7 @@
 - [Enhancement] Support time ranges for graphs in OSS.
 - [Enhancement] Report last poll time for each subscription group.
 - [Enhancement] Show last poll time per consumer instance.
+- [Change] Rename "Busy" to "Running" to align with "Running Jobs".
 - [Change] Rename "Active subscriptions" to "Subscriptions" as process subscriptions are always active.
 - [Maintenance] Introduce granular subscription group contracts.
 

--- a/lib/karafka/web/ui/app.rb
+++ b/lib/karafka/web/ui/app.rb
@@ -49,9 +49,14 @@ module Karafka
           end
 
           r.on 'jobs' do
+            controller = Controllers::Jobs.new(params)
+
             r.get 'running' do
-              controller = Controllers::Jobs.new(params)
               controller.running
+            end
+
+            r.get 'pending' do
+              controller.pending
             end
 
             r.redirect root_path('jobs/running')

--- a/lib/karafka/web/ui/controllers/jobs.rb
+++ b/lib/karafka/web/ui/controllers/jobs.rb
@@ -11,6 +11,8 @@ module Karafka
             current_state = Models::ConsumersState.current!
             processes = Models::Processes.active(current_state)
 
+            @jobs_counters = count_jobs_types(processes)
+
             # Aggregate jobs and inject the process info into them for better reporting
             jobs_total = processes.flat_map do |process|
               process.jobs.running.map do |job|
@@ -27,6 +29,46 @@ module Karafka
             paginate(@params.current_page, !last_page)
 
             render
+          end
+
+          # Lists pending jobs
+          def pending
+            current_state = Models::ConsumersState.current!
+            processes = Models::Processes.active(current_state)
+
+            @jobs_counters = count_jobs_types(processes)
+
+            # Aggregate jobs and inject the process info into them for better reporting
+            jobs_total = processes.flat_map do |process|
+              process.jobs.pending.map do |job|
+                job.to_h[:process] = process
+                job
+              end
+            end
+
+            @jobs, last_page = Ui::Lib::Paginations::Paginators::Arrays.call(
+              jobs_total,
+              @params.current_page
+            )
+
+            paginate(@params.current_page, !last_page)
+
+            render
+          end
+
+          private
+
+          # @param processes [Array<Models::Process>]
+          # @return [Lib::HashProxy] particular type jobs count
+          def count_jobs_types(processes)
+            counts = { running: 0, pending: 0 }
+
+            processes.flat_map do |process|
+              counts[:running] += process.jobs.running.size
+              counts[:pending] += process.jobs.pending.size
+            end
+
+            Lib::HashProxy.new(counts)
           end
         end
       end

--- a/lib/karafka/web/ui/models/jobs.rb
+++ b/lib/karafka/web/ui/models/jobs.rb
@@ -23,6 +23,11 @@ module Karafka
             select { |job| job.status == 'running' }
           end
 
+          # @return [Jobs] pending jobs
+          def pending
+            select { |job| job.status == 'pending' }
+          end
+
           # Creates a new Jobs object with selected jobs
           # @param block [Proc] select proc
           # @return [Jobs] selected jobs enclosed with the Jobs object

--- a/lib/karafka/web/ui/pro/app.rb
+++ b/lib/karafka/web/ui/pro/app.rb
@@ -54,6 +54,10 @@ module Karafka
                   controller.running_jobs(process_id)
                 end
 
+                r.get 'pending' do
+                  controller.pending_jobs(process_id)
+                end
+
                 r.redirect root_path("consumers/#{process_id}/jobs/running")
               end
 
@@ -72,9 +76,14 @@ module Karafka
             end
 
             r.on 'jobs' do
+              controller = Controllers::Jobs.new(params)
+
               r.get 'running' do
-                controller = Controllers::Jobs.new(params)
                 controller.running
+              end
+
+              r.get 'pending' do
+                controller.pending
               end
 
               r.redirect root_path('jobs/running')

--- a/lib/karafka/web/ui/pro/controllers/consumers.rb
+++ b/lib/karafka/web/ui/pro/controllers/consumers.rb
@@ -48,6 +48,14 @@ module Karafka
               render
             end
 
+            # Renders details about pending jobs
+            #
+            # @param process_id [String] id of the process we're interested in
+            def pending_jobs(process_id)
+              details(process_id)
+              render
+            end
+
             # @param process_id [String] id of the process we're interested in
             def subscriptions(process_id)
               details(process_id)

--- a/lib/karafka/web/ui/pro/views/consumers/_counters.erb
+++ b/lib/karafka/web/ui/pro/views/consumers/_counters.erb
@@ -24,18 +24,20 @@
                 <div class="desc">Lag stored</div>
               </li>
               <li class="col-sm">
-                <a href="<%= root_path('jobs') %>">
+                <a href="<%= root_path('jobs/running') %>">
                   <div class="count mb-1">
                     <%= number_with_delimiter @counters.busy, ' ' %>
                   </div>
-                  <div class="desc">Busy</div>
+                  <div class="desc">Running</div>
                 </a>
               </li>
               <li class="col-sm">
-                <div class="count mb-1">
-                  <%= number_with_delimiter @counters.pending, ' ' %>
-                </div>
-                <div class="desc">Pending</div>
+                <a href="<%= root_path('jobs/pending') %>">
+                  <div class="count mb-1">
+                    <%= number_with_delimiter @counters.pending, ' ' %>
+                  </div>
+                  <div class="desc">Pending</div>
+                </a>
               </li>
               <li class="col-sm">
                 <a href="<%= root_path('errors') %>">

--- a/lib/karafka/web/ui/pro/views/consumers/consumer/_no_jobs.erb
+++ b/lib/karafka/web/ui/pro/views/consumers/consumer/_no_jobs.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-lg-12">
       <div class="alert alert-info" role="alert">
-        This process is not running any jobs at the moment.
+        This process has no <%= type %> jobs at the moment.
       </div>
     </div>
   </div>

--- a/lib/karafka/web/ui/pro/views/consumers/consumer/_tabs.erb
+++ b/lib/karafka/web/ui/pro/views/consumers/consumer/_tabs.erb
@@ -11,9 +11,16 @@
         </li>
 
         <li class="nav-item">
-          <a class="nav-link <%= nav_class(include: 'jobs') %>" href="<%= root_path('consumers', @process.id, 'jobs', 'running') %>">
+          <a class="nav-link <%= nav_class(include: 'jobs/running') %>" href="<%= root_path('consumers', @process.id, 'jobs', 'running') %>">
             Running jobs
             (<%= @process.jobs.running.count %>)
+          </a>
+        </li>
+
+        <li class="nav-item">
+          <a class="nav-link <%= nav_class(include: 'jobs/pending') %>" href="<%= root_path('consumers', @process.id, 'jobs', 'pending') %>">
+            Pending jobs
+            (<%= @process.jobs.pending.count %>)
           </a>
         </li>
 

--- a/lib/karafka/web/ui/pro/views/consumers/pending_jobs.erb
+++ b/lib/karafka/web/ui/pro/views/consumers/pending_jobs.erb
@@ -1,4 +1,4 @@
-<% running_jobs = @process.jobs.running %>
+<% pending_jobs = @process.jobs.pending %>
 
 <%== view_title(@process.name) %>
 
@@ -10,8 +10,8 @@
 
 <%== partial 'consumers/consumer/tabs' %>
 
-<% if running_jobs.empty? %>
-  <%== partial 'consumers/consumer/no_jobs', locals: { type: 'running' } %>
+<% if pending_jobs.empty? %>
+  <%== partial 'consumers/consumer/no_jobs', locals: { type: 'pending' } %>
 <% else %>
   <div class="container">
     <div class="row mb-5">
@@ -25,13 +25,13 @@
               <th>First offset</th>
               <th>Last offset</th>
               <th>Committed offset</th>
-              <th>Started at</th>
+              <th>Scheduled at</th>
             </tr>
           </thead>
           <tbody>
             <%==
               render_each(
-                running_jobs,
+                pending_jobs,
                 'consumers/consumer/_job',
                 local: :job
               )

--- a/lib/karafka/web/ui/pro/views/jobs/_no_jobs.erb
+++ b/lib/karafka/web/ui/pro/views/jobs/_no_jobs.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-lg-12">
       <div class="alert alert-info" role="alert">
-        There are no running jobs at the moment.
+        There are no <%= type %> jobs at the moment.
       </div>
     </div>
   </div>

--- a/lib/karafka/web/ui/pro/views/jobs/pending.erb
+++ b/lib/karafka/web/ui/pro/views/jobs/pending.erb
@@ -1,7 +1,9 @@
-<%== view_title('Running jobs', hr: true) %>
+<%== view_title('Pending jobs overview', hr: false) %>
+
+<%== partial 'jobs/tabs' %>
 
 <% if @jobs.empty? && params.current_page <= 1 %>
-  <%== partial 'jobs/no_jobs', locals: { type: 'running' } %>
+  <%== partial 'jobs/no_jobs', locals: { type: 'pending' } %>
 <% elsif @jobs.empty? %>
   <%== partial 'shared/no_paginated_data' %>
 <% else %>
@@ -15,7 +17,11 @@
               <th>Topic</th>
               <th>Consumer</th>
               <th>Type</th>
-              <th>Started at</th>
+              <th>Messages</th>
+              <th>First offset</th>
+              <th>Last offset</th>
+              <th>Committed offset</th>
+              <th>Created at</th>
             </tr>
           </thead>
           <tbody>

--- a/lib/karafka/web/ui/pro/views/jobs/running.erb
+++ b/lib/karafka/web/ui/pro/views/jobs/running.erb
@@ -1,7 +1,9 @@
-<%== view_title('Running jobs', hr: true) %>
+<%== view_title('Running jobs overview', hr: false) %>
+
+<%== partial 'jobs/tabs' %>
 
 <% if @jobs.empty? && params.current_page <= 1 %>
-  <%== partial 'jobs/no_jobs' %>
+  <%== partial 'jobs/no_jobs', locals: { type: 'running' } %>
 <% elsif @jobs.empty? %>
   <%== partial 'shared/no_paginated_data' %>
 <% else %>

--- a/lib/karafka/web/ui/views/consumers/_counters.erb
+++ b/lib/karafka/web/ui/views/consumers/_counters.erb
@@ -24,18 +24,20 @@
                 <div class="desc">Lag stored</div>
               </li>
               <li class="col-sm">
-                <a href="<%= root_path('jobs') %>">
+                <a href="<%= root_path('jobs/running') %>">
                   <div class="count mb-1">
                     <%= number_with_delimiter @counters.busy, ' ' %>
                   </div>
-                  <div class="desc">Busy</div>
+                  <div class="desc">Running</div>
                 </a>
               </li>
               <li class="col-sm">
-                <div class="count mb-1">
-                  <%= number_with_delimiter @counters.pending, ' ' %>
-                </div>
-                <div class="desc">Pending</div>
+                <a href="<%= root_path('jobs/pending') %>">
+                  <div class="count mb-1">
+                    <%= number_with_delimiter @counters.pending, ' ' %>
+                  </div>
+                  <div class="desc">Pending</div>
+                </a>
               </li>
               <li class="col-sm">
                 <a href="<%= root_path('errors') %>">

--- a/lib/karafka/web/ui/views/jobs/_breadcrumbs.erb
+++ b/lib/karafka/web/ui/views/jobs/_breadcrumbs.erb
@@ -4,8 +4,18 @@
   </a>
 </li>
 
-<li class="breadcrumb-item">
-  <a href="<%= root_path('jobs') %>">
-    Running
-  </a>
-</li>
+<% if current_path.include?('/running') %>
+  <li class="breadcrumb-item">
+    <a href="<%= root_path('jobs/running') %>">
+      Running
+    </a>
+  </li>
+<% end %>
+
+<% if current_path.include?('/pending') %>
+  <li class="breadcrumb-item">
+    <a href="<%= root_path('jobs/pending') %>">
+      Pending
+    </a>
+  </li>
+<% end %>

--- a/lib/karafka/web/ui/views/jobs/_no_jobs.erb
+++ b/lib/karafka/web/ui/views/jobs/_no_jobs.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-lg-12">
       <div class="alert alert-info" role="alert">
-        There are no running jobs at the moment.
+        There are no <%= type %> jobs at the moment.
       </div>
     </div>
   </div>

--- a/lib/karafka/web/ui/views/jobs/_tabs.erb
+++ b/lib/karafka/web/ui/views/jobs/_tabs.erb
@@ -1,0 +1,27 @@
+<div class="container">
+  <div class="row mb-5">
+    <div class="col-sm-12">
+
+      <ul class="nav nav-tabs">
+        <li class="nav-item">
+          <a
+            class="nav-link <%= nav_class(include: 'running') %>"
+            href="<%= root_path('jobs', 'running') %>"
+          >
+            Running (<%= @jobs_counters.running %>)
+          </a>
+        </li>
+
+        <li class="nav-item">
+          <a
+            class="nav-link <%= nav_class(include: 'pending') %>"
+            href="<%= root_path('jobs', 'pending') %>"
+          >
+            Pending (<%= @jobs_counters.pending %>)
+          </a>
+        </li>
+      </ul>
+
+    </div>
+  </div>
+</div>

--- a/lib/karafka/web/ui/views/jobs/pending.erb
+++ b/lib/karafka/web/ui/views/jobs/pending.erb
@@ -1,7 +1,7 @@
-<%== view_title('Running jobs', hr: true) %>
+<%== view_title('Pending jobs', hr: true) %>
 
 <% if @jobs.empty? && params.current_page <= 1 %>
-  <%== partial 'jobs/no_jobs', locals: { type: 'running' } %>
+  <%== partial 'jobs/no_jobs', locals: { type: 'pending' } %>
 <% elsif @jobs.empty? %>
   <%== partial 'shared/no_paginated_data' %>
 <% else %>
@@ -15,7 +15,7 @@
               <th>Topic</th>
               <th>Consumer</th>
               <th>Type</th>
-              <th>Started at</th>
+              <th>Scheduled at</th>
             </tr>
           </thead>
           <tbody>

--- a/spec/lib/karafka/web/ui/controllers/jobs_spec.rb
+++ b/spec/lib/karafka/web/ui/controllers/jobs_spec.rb
@@ -169,4 +169,170 @@ RSpec.describe_current do
       end
     end
   end
+
+  describe '#pending' do
+    context 'when needed topics are missing' do
+      before do
+        topics_config.consumers.states = SecureRandom.uuid
+        topics_config.consumers.metrics = SecureRandom.uuid
+        topics_config.consumers.reports = SecureRandom.uuid
+        topics_config.errors = SecureRandom.uuid
+
+        get 'jobs/pending'
+      end
+
+      it do
+        expect(response).not_to be_ok
+        expect(status).to eq(404)
+      end
+    end
+
+    context 'when needed topics are present with data' do
+      before do
+        topics_config.consumers.states = states_topic
+        topics_config.consumers.reports = reports_topic
+
+        data = Fixtures.json('consumers_state', symbolize_names: false)
+        report = Fixtures.json('consumer_report', symbolize_names: false)
+        report['jobs'][0]['status'] = 'pending'
+
+        produce(reports_topic, report.to_json)
+        produce(states_topic, data.to_json)
+
+        get 'jobs/pending'
+      end
+
+      it do
+        expect(response).to be_ok
+        expect(body).to include('2023-08-01T09:47:51')
+        expect(body).to include('ActiveJob::Consumer')
+        expect(body).to include(support_message)
+        expect(body).to include(breadcrumbs)
+        expect(body).not_to include(pagination)
+      end
+    end
+
+    context 'when we have only jobs different than pending' do
+      before do
+        topics_config.consumers.states = states_topic
+        topics_config.consumers.reports = reports_topic
+
+        data = Fixtures.json('consumers_state', symbolize_names: false)
+        report = Fixtures.json('consumer_report', symbolize_names: false)
+        report['jobs'][0]['status'] = 'running'
+
+        produce(reports_topic, report.to_json)
+        produce(states_topic, data.to_json)
+
+        get 'jobs/pending'
+      end
+
+      it do
+        expect(response).to be_ok
+        expect(body).to include('There are no pending jobs at the moment')
+        expect(body).not_to include('ActiveJob::Consumer')
+        expect(body).to include(support_message)
+        expect(body).to include(breadcrumbs)
+        expect(body).not_to include(pagination)
+      end
+    end
+
+    context 'when there are more jobs than fits on a single page' do
+      before do
+        topics_config.consumers.states = states_topic
+        topics_config.consumers.reports = reports_topic
+
+        data = Fixtures.json('consumers_state', symbolize_names: false)
+        base_report = Fixtures.json('consumer_report', symbolize_names: false)
+
+        100.times do |i|
+          name = "shinra:#{i}:#{i}"
+
+          data['processes'][name] = {
+            dispatched_at: 2_690_818_669.526_218,
+            offset: i
+          }
+
+          report = base_report.dup
+          report['process']['name'] = name
+          report['jobs'].first['status'] = 'pending'
+
+          produce(reports_topic, report.to_json, key: name)
+        end
+
+        produce(states_topic, data.to_json)
+      end
+
+      context 'when visiting first page' do
+        before { get 'jobs/pending' }
+
+        it do
+          expect(response).to be_ok
+          expect(body).to include('2023-08-01T09:47:51')
+          expect(body.scan('ActiveJob::Consumer').size).to eq(25)
+          expect(body).to include(support_message)
+          expect(body).to include(breadcrumbs)
+          expect(body).to include(pagination)
+          expect(body).to include('shinra:0:0')
+          expect(body).to include('shinra:1:1')
+          expect(body).to include('shinra:11:11')
+          expect(body).to include('shinra:12:12')
+          expect(body.scan('shinra:').size).to eq(25)
+        end
+      end
+
+      context 'when visiting page with data reported in a transactional fashion' do
+        before do
+          topics_config.consumers.states = states_topic
+          topics_config.consumers.reports = reports_topic
+
+          produce(states_topic, Fixtures.file('consumers_state.json'), type: :transactional)
+          produce(reports_topic, Fixtures.file('consumer_report.json'), type: :transactional)
+
+          get 'jobs/pending'
+        end
+
+        it do
+          expect(response).to be_ok
+          expect(body).to include('2023-08-01T09:47:51')
+          expect(body.scan('ActiveJob::Consumer').size).to eq(25)
+          expect(body).to include(support_message)
+          expect(body).to include(breadcrumbs)
+          expect(body).to include(pagination)
+          expect(body).to include('shinra:0:0')
+          expect(body).to include('shinra:1:1')
+          expect(body).to include('shinra:11:11')
+          expect(body).to include('shinra:12:12')
+          expect(body.scan('shinra:').size).to eq(25)
+        end
+      end
+
+      context 'when visiting higher page' do
+        before { get 'jobs/pending?page=2' }
+
+        it do
+          expect(response).to be_ok
+          expect(body).to include(pagination)
+          expect(body).to include(support_message)
+          expect(body).to include('shinra:32:32')
+          expect(body).to include('shinra:34:34')
+          expect(body).to include('shinra:35:35')
+          expect(body).to include('shinra:35:35')
+          expect(body.scan('shinra:').size).to eq(25)
+        end
+      end
+
+      context 'when visiting page beyond available' do
+        before { get 'jobs/pending?page=100' }
+
+        it do
+          expect(response).to be_ok
+          expect(body).to include(pagination)
+          expect(body).to include(support_message)
+          expect(body.scan('shinra:').size).to eq(0)
+          expect(body).to include(no_meaningful_results)
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/karafka/web/ui/models/jobs_spec.rb
+++ b/spec/lib/karafka/web/ui/models/jobs_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe_current do
     it { expect(jobs.running.size).to eq(1) }
   end
 
+  describe '#pending' do
+    it { expect(jobs.pending.size).to eq(0) }
+  end
+
   describe '#select' do
     it 'expect to return selection enclosed in jobs collection' do
       result = jobs.select(&:nil?)

--- a/spec/lib/karafka/web/ui/pro/controllers/jobs_spec.rb
+++ b/spec/lib/karafka/web/ui/pro/controllers/jobs_spec.rb
@@ -169,4 +169,171 @@ RSpec.describe_current do
       end
     end
   end
+
+  describe '#pending' do
+    context 'when needed topics are missing' do
+      before do
+        topics_config.consumers.states = SecureRandom.uuid
+        topics_config.consumers.metrics = SecureRandom.uuid
+        topics_config.consumers.reports = SecureRandom.uuid
+        topics_config.errors = SecureRandom.uuid
+
+        get 'jobs/pending'
+      end
+
+      it do
+        expect(response).not_to be_ok
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'when needed topics are present with data' do
+      before do
+        topics_config.consumers.states = states_topic
+        topics_config.consumers.reports = reports_topic
+
+        data = Fixtures.json('consumers_state', symbolize_names: false)
+        report = Fixtures.json('consumer_report', symbolize_names: false)
+        report['jobs'][0]['status'] = 'pending'
+
+        produce(reports_topic, report.to_json)
+        produce(states_topic, data.to_json)
+
+        get 'jobs/pending'
+      end
+
+      it do
+        expect(response).to be_ok
+        expect(body).to include('2023-08-01T09:47:51')
+        expect(body).to include('ActiveJob::Consumer')
+        expect(body).not_to include(support_message)
+        expect(body).to include(breadcrumbs)
+        expect(body).not_to include(pagination)
+      end
+    end
+
+    context 'when we have only jobs different than pending' do
+      before do
+        topics_config.consumers.states = states_topic
+        topics_config.consumers.reports = reports_topic
+
+        data = Fixtures.json('consumers_state', symbolize_names: false)
+        report = Fixtures.json('consumer_report', symbolize_names: false)
+        report['jobs'][0]['status'] = 'running'
+
+        produce(reports_topic, report.to_json)
+        produce(states_topic, data.to_json)
+
+        get 'jobs/pending'
+      end
+
+      it do
+        expect(response).to be_ok
+        expect(body).to include('There are no pending jobs at the moment')
+        expect(body).not_to include('ActiveJob::Consumer')
+        expect(body).not_to include(support_message)
+        expect(body).to include(breadcrumbs)
+        expect(body).not_to include(pagination)
+      end
+    end
+
+    context 'when there are more jobs than fits on a single page' do
+      before do
+        topics_config.consumers.states = states_topic
+        topics_config.consumers.reports = reports_topic
+
+        data = Fixtures.json('consumers_state', symbolize_names: false)
+        base_report = Fixtures.json('consumer_report', symbolize_names: false)
+
+        base_report['jobs'].first['status'] = 'pending'
+
+        100.times do |i|
+          name = "shinra:#{i}:#{i}"
+
+          data['processes'][name] = {
+            dispatched_at: 2_690_818_669.526_218,
+            offset: i
+          }
+
+          report = base_report.dup
+          report['process']['name'] = name
+
+          produce(reports_topic, report.to_json, key: name)
+        end
+
+        produce(states_topic, data.to_json)
+      end
+
+      context 'when visiting first page' do
+        before { get 'jobs/pending' }
+
+        it do
+          expect(response).to be_ok
+          expect(body).to include('2023-08-01T09:47:51')
+          expect(body.scan('ActiveJob::Consumer').size).to eq(25)
+          expect(body).not_to include(support_message)
+          expect(body).to include(breadcrumbs)
+          expect(body).to include(pagination)
+          expect(body).to include('shinra:0:0')
+          expect(body).to include('shinra:1:1')
+          expect(body).to include('shinra:11:11')
+          expect(body).to include('shinra:12:12')
+          expect(body.scan('shinra:').size).to eq(25)
+        end
+      end
+
+      context 'when visiting page with data published in a transactional fashion' do
+        before do
+          topics_config.consumers.states = states_topic
+          topics_config.consumers.reports = reports_topic
+
+          produce(states_topic, Fixtures.file('consumers_state.json'), type: :transactional)
+          produce(reports_topic, Fixtures.file('consumer_report.json'), type: :transactional)
+
+          get 'jobs/pending'
+        end
+
+        it do
+          expect(response).to be_ok
+          expect(body).to include('2023-08-01T09:47:51')
+          expect(body.scan('ActiveJob::Consumer').size).to eq(25)
+          expect(body).not_to include(support_message)
+          expect(body).to include(breadcrumbs)
+          expect(body).to include(pagination)
+          expect(body).to include('shinra:0:0')
+          expect(body).to include('shinra:1:1')
+          expect(body).to include('shinra:11:11')
+          expect(body).to include('shinra:12:12')
+          expect(body.scan('shinra:').size).to eq(25)
+        end
+      end
+
+      context 'when visiting higher page' do
+        before { get 'jobs/pending?page=2' }
+
+        it do
+          expect(response).to be_ok
+          expect(body).to include(pagination)
+          expect(body).not_to include(support_message)
+          expect(body).to include('shinra:32:32')
+          expect(body).to include('shinra:34:34')
+          expect(body).to include('shinra:35:35')
+          expect(body).to include('shinra:35:35')
+          expect(body.scan('shinra:').size).to eq(25)
+        end
+      end
+
+      context 'when visiting page beyond available' do
+        before { get 'jobs/pending?page=100' }
+
+        it do
+          expect(response).to be_ok
+          expect(body).to include(pagination)
+          expect(body).not_to include(support_message)
+          expect(body.scan('shinra:').size).to eq(0)
+          expect(body).to include(no_meaningful_results)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR introduces:

Global pending jobs visibility:

![image](https://github.com/karafka/karafka-web/assets/392754/49e807d6-090f-4bcb-811a-8b3a98e1d5fd)

Per process pending jobs visibility:

![image](https://github.com/karafka/karafka-web/assets/392754/a259675e-5842-441a-8d65-655eaf2ad5e6)

close https://github.com/karafka/karafka-web/issues/207