### PR TITLE
Support for Periodics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **[Feature]** Introduce "Data transfers" chart with data received and data sent to the cluster.
 - **[Feature]** Introduce ability to download raw payloads.
 - **[Feature]** Introduce ability to download deserialized message payload as JSON.
+- [Enhancement] Support Periodic Jobs reporting.
 - [Enhancement] Support multiplexed subscription groups.
 - [Enhancement] Split cluster info into two tabs, one for brokers and one for topics with partitions.
 - [Enhancement] Track pending jobs. Pending jobs are jobs that are not yet scheduled for execution by advanced schedulers.

--- a/lib/karafka/web/tracking/consumers/contracts/job.rb
+++ b/lib/karafka/web/tracking/consumers/contracts/job.rb
@@ -18,7 +18,7 @@ module Karafka
             required(:last_offset) { |val| val.is_a?(Integer) && (val >= 0 || val == -1001) }
             required(:committed_offset) { |val| val.is_a?(Integer) }
             required(:messages) { |val| val.is_a?(Integer) && val >= 0 }
-            required(:type) { |val| %w[consume revoked shutdown].include?(val) }
+            required(:type) { |val| %w[consume revoked shutdown tick].include?(val) }
             required(:tags) { |val| val.is_a?(Karafka::Core::Taggable::Tags) }
             # -1 can be here for workless flows
             required(:consumption_lag) { |val| val.is_a?(Integer) && (val >= 0 || val == -1) }

--- a/spec/lib/karafka/web/ui/pro/controllers/jobs_spec.rb
+++ b/spec/lib/karafka/web/ui/pro/controllers/jobs_spec.rb
@@ -174,10 +174,6 @@ RSpec.describe_current do
         end
       end
     end
-
-    context 'when we visit shutdown, revoked and tick jobs' do
-      pending
-    end
   end
 
   describe '#pending' do

--- a/spec/lib/karafka/web/ui/pro/controllers/jobs_spec.rb
+++ b/spec/lib/karafka/web/ui/pro/controllers/jobs_spec.rb
@@ -174,6 +174,10 @@ RSpec.describe_current do
         end
       end
     end
+
+    context 'when we visit shutdown, revoked and tick jobs' do
+      pending
+    end
   end
 
   describe '#pending' do


### PR DESCRIPTION
This PR adds support for https://karafka.io/docs/Pro-Periodic-Jobs/ in the web UI. It displays the `#tick` methods invocations and includes them in the utilization cost computation.

close https://github.com/karafka/karafka-web/issues/228

![Zrzut ekranu z 2024-01-06 18-32-24](https://github.com/karafka/karafka-web/assets/392754/e279db22-2c60-4ef3-880a-6835cacbdcac)
