### PR TITLE
Make sure routing setup is prior to running migration on fresh install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [Enhancement] Report lag on consumers that did not yet marked offsets.
 - [Enhancement] Use more accurate lag reporting that compensates for lack of stored lag.
 - [Fix] When first message after process start is crashed without DLQ lag is not reported.
+- [Fix] Wrong order of enabled injection causes fresh install to crash.
 
 ## 0.8.0 (2024-01-26)
 - **[Feature]** Provide ability to sort table data for part of the views (note: not all attributes can be sorted due to technical limitations of sub-components fetching from Kafka).

--- a/lib/karafka/web/config.rb
+++ b/lib/karafka/web/config.rb
@@ -6,6 +6,10 @@ module Karafka
     class Config
       include ::Karafka::Core::Configurable
 
+      # Is the Web UI enabled and things were configured.
+      # Automatically set to true in case things got enabled.
+      setting :enabled, default: false
+
       # How long do we consider the process alive without receiving status info about it
       # For this long we also display dead processes (shutdown) in the UI
       # This is used both in the processing for eviction and in the UI

--- a/lib/karafka/web/contracts/config.rb
+++ b/lib/karafka/web/contracts/config.rb
@@ -10,6 +10,7 @@ module Karafka
         # Use the same regexp as Karafka for topics validation
         TOPIC_REGEXP = ::Karafka::Contracts::TOPIC_REGEXP
 
+        required(:enabled) { |val| [true, false, nil].include?(val) }
         required(:ttl) { |val| val.is_a?(Numeric) && val.positive? }
 
         nested(:topics) do

--- a/lib/karafka/web/installer.rb
+++ b/lib/karafka/web/installer.rb
@@ -15,16 +15,17 @@ module Karafka
         puts
         puts 'Installing Karafka Web UI...'
         puts
+        Management::Actions::ExtendBootFile.new.call
+        puts
         puts 'Creating necessary topics and populating state data...'
         puts
         Management::Actions::CreateTopics.new.call(replication_factor)
         wait_for_topics
+        enable!
         Management::Actions::CreateInitialStates.new.call
         puts
         puts 'Running data migrations...'
         Management::Actions::MigrateStatesData.new.call
-        puts
-        Management::Actions::ExtendBootFile.new.call
         puts
         puts("Installation #{green('completed')}. Have fun!")
         puts

--- a/lib/karafka/web/management/actions/enable.rb
+++ b/lib/karafka/web/management/actions/enable.rb
@@ -10,6 +10,11 @@ module Karafka
         class Enable < Base
           # Enables routing consumer group and subscribes Web-UI listeners
           def call
+            # Prevent double enabling
+            return if ::Karafka::Web.config.enabled
+
+            ::Karafka::Web.config.enabled = true
+
             extend_routing
             setup_tracking_activity
 

--- a/lib/karafka/web/management/actions/extend_boot_file.rb
+++ b/lib/karafka/web/management/actions/extend_boot_file.rb
@@ -22,7 +22,9 @@ module Karafka
 
           # Adds needed code
           def call
-            if File.read(Karafka.boot_file).include?(ENABLER_CODE)
+            # We detect this that way so in case our template or user has enabled as a comment
+            # it still adds the template and runs install
+            if File.readlines(Karafka.boot_file).any? { |line| line.start_with?(ENABLER_CODE) }
               puts "Web UI #{already} installed."
             else
               puts 'Updating the Karafka boot file...'

--- a/spec/lib/karafka/web/contracts/config_spec.rb
+++ b/spec/lib/karafka/web/contracts/config_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe_current do
 
   let(:params) do
     {
+      enabled: true,
       ttl: 5000,
       topics: {
         errors: 'errors-topic',
@@ -52,6 +53,12 @@ RSpec.describe_current do
     it 'is valid' do
       expect(contract.call(params)).to be_success
     end
+  end
+
+  context 'when enabled is not boolean' do
+    before { params[:enabled] = 'string_value' }
+
+    it { expect(contract.call(params)).not_to be_success }
   end
 
   context 'when ttl is not numeric' do


### PR DESCRIPTION
This PR:
- makes sure we cannot double-enable web-ui - while here it is a side effect it was part of a different user struggle
- injects routing and deserialization logic PRIOR to migrations, making sure proper deserializer is selected
- installs web-ui even if enabled code is present as long as it is commented out

close https://github.com/karafka/karafka-web/issues/259
close https://github.com/karafka/karafka-web/issues/260
