### PR TITLE
Check migration inheritance via ancestors array

### DIFF
--- a/lib/karafka/web/management/migrations/0_base.rb
+++ b/lib/karafka/web/management/migrations/0_base.rb
@@ -47,7 +47,7 @@ module Karafka
             def sorted_descendants
               ObjectSpace
                 .each_object(Class)
-                .select { |klass| klass < self }
+                .select { |klass| klass != self && klass.ancestors.include?(self) }
                 .sort_by(&:index)
             end
           end


### PR DESCRIPTION
In some (perhaps misguided) cases, classes elsewhere (i.e. in a Rails app, or in another gem that's also been loaded) may override the <=> method (on the class, not the instance). This causes the inheritance check via the less-than operator to throw an exception.

So instead, let’s use the `ancestors` method, which is less likely to be altered by other code. A class’s ancestors always includes itself, so we need to ignore the base class as well.