### PR TITLE
fix 404 recom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Fix] Fix a case where on mobile charts would not load correctly.
 - [Fix] Fix cases where long consumer names would break UI.
 - [Fix] Explorer deserializer wrongly selected for pattern matched topics.
+- [Fix] Fix 404 error page invalid recommendation of `install` instead of `migrate`.
 
 ## 0.8.2 (2024-02-16)
 - [Enhancement] Defer scheduler background thread creation until needed allowing for forks.

--- a/lib/karafka/web/ui/views/shared/exceptions/not_found.erb
+++ b/lib/karafka/web/ui/views/shared/exceptions/not_found.erb
@@ -23,7 +23,7 @@
           <ul class="mb-5 text-start">
             <li>You have visited the <a href="<%= root_path('status') %>">Status</a> page to troubleshoot any potential issues</li>
             <li>All the topics required by Karafka Web exist</li>
-            <li>You have used <code>bundle exec karafka-web install</code> to initialize the Web UI</li>
+            <li>You have used <code>bundle exec karafka-web migrate</code> to initialize the Web UI</li>
             <li>You have a working connection with your Kafka cluster</li>
             <li>The resource you requested exists</li>
           </ul>


### PR DESCRIPTION
we have changed the command to `migrate` while ago to differentiate. This PR aligns the 404 (other places are aligned)