### PR TITLE
compress commands and make topic explorer better

### DIFF
--- a/lib/karafka/web/pro/ui/app.rb
+++ b/lib/karafka/web/pro/ui/app.rb
@@ -262,15 +262,15 @@ module Karafka
             r.on 'topics' do
               controller = Controllers::TopicsController.new(params)
 
-              r.get 'config', String do |topic_name|
+              r.get String, 'config' do |topic_name|
                 controller.config(topic_name)
               end
 
-              r.get 'replication', String do |topic_name|
+              r.get String, 'replication' do |topic_name|
                 controller.replication(topic_name)
               end
 
-              r.get 'distribution', String do |topic_name|
+              r.get String, 'distribution' do |topic_name|
                 controller.distribution(topic_name)
               end
 

--- a/lib/karafka/web/pro/ui/views/topics/_breadcrumbs.erb
+++ b/lib/karafka/web/pro/ui/views/topics/_breadcrumbs.erb
@@ -6,7 +6,7 @@
 
 <% if @topic %>
   <li class="breadcrumb-item">
-    <a href="<%= root_path('topics', 'config', @topic.topic_name) %>">
+    <a href="<%= root_path('topics', @topic.topic_name, 'config') %>">
       <%= @topic.topic_name %>
     </a>
   </li>
@@ -14,7 +14,7 @@
 
 <% if @configs %>
   <li class="breadcrumb-item">
-    <a href="<%= root_path('topics', 'config', @topic.topic_name) %>">
+    <a href="<%= root_path('topics', @topic.topic_name, 'config') %>">
       Configuration
     </a>
   </li>
@@ -22,7 +22,7 @@
 
 <% if @partitions %>
   <li class="breadcrumb-item">
-    <a href="<%= root_path('topics', 'replication', @topic.topic_name) %>">
+    <a href="<%= root_path('topics', @topic.topic_name, 'replication') %>">
       Replication
     </a>
   </li>
@@ -30,7 +30,7 @@
 
 <% if @distribution %>
   <li class="breadcrumb-item">
-    <a href="<%= root_path('topics', 'distribution', @topic.topic_name) %>">
+    <a href="<%= root_path('topics', @topic.topic_name, 'distribution') %>">
       Distribution
     </a>
   </li>

--- a/lib/karafka/web/pro/ui/views/topics/_tabs.erb
+++ b/lib/karafka/web/pro/ui/views/topics/_tabs.erb
@@ -5,8 +5,8 @@
       <ul class="nav nav-tabs">
         <li class="nav-item">
           <a
-            class="nav-link <%= nav_class(include: 'config') %>"
-            href="<%= root_path('topics', 'config', @topic.topic_name) %>"
+            class="nav-link <%= nav_class(end_with: 'config') %>"
+            href="<%= root_path('topics', @topic.topic_name, 'config') %>"
           >
             Configuration
           </a>
@@ -14,8 +14,8 @@
 
         <li class="nav-item">
           <a
-            class="nav-link <%= nav_class(include: 'replication') %>"
-            href="<%= root_path('topics', 'replication', @topic.topic_name) %>"
+            class="nav-link <%= nav_class(end_with: 'replication') %>"
+            href="<%= root_path('topics', @topic.topic_name, 'replication') %>"
           >
             Replication
           </a>
@@ -23,8 +23,8 @@
 
         <li class="nav-item">
           <a
-            class="nav-link <%= nav_class(include: 'distribution') %>"
-            href="<%= root_path('topics', 'distribution', @topic.topic_name) %>"
+            class="nav-link <%= nav_class(end_with: 'distribution') %>"
+            href="<%= root_path('topics', @topic.topic_name, 'distribution') %>"
           >
             Distribution
           </a>

--- a/lib/karafka/web/pro/ui/views/topics/_topic.erb
+++ b/lib/karafka/web/pro/ui/views/topics/_topic.erb
@@ -2,7 +2,7 @@
   <div class="card" >
     <div class="card-body p-2">
       <p class="card-text mb-0 p-2">
-        <a href="<%= root_path('topics', 'config', topic.topic_name) %>">
+        <a href="<%= root_path('topics', topic.topic_name, 'config') %>">
           <%= topic.topic_name %> /
           <%= topic.partition_count %>
         </a>

--- a/spec/lib/karafka/web/pro/ui/controllers/topics_controller_spec.rb
+++ b/spec/lib/karafka/web/pro/ui/controllers/topics_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe_current do
 
   describe '#config' do
     context 'when trying to read configs of a non-existing topic' do
-      before { get "topics/config/#{SecureRandom.uuid}" }
+      before { get "topics/#{SecureRandom.uuid}/config" }
 
       it do
         expect(response).not_to be_ok
@@ -75,7 +75,7 @@ RSpec.describe_current do
     end
 
     context 'when getting configs of an existing topic' do
-      before { get "topics/config/#{topic}" }
+      before { get "topics/#{topic}/config" }
 
       it do
         expect(response).to be_ok
@@ -92,7 +92,7 @@ RSpec.describe_current do
 
   describe '#replication' do
     context 'when trying to read configs of a non-existing topic' do
-      before { get "topics/replication/#{SecureRandom.uuid}" }
+      before { get "topics/#{SecureRandom.uuid}/replication" }
 
       it do
         expect(response).not_to be_ok
@@ -101,7 +101,7 @@ RSpec.describe_current do
     end
 
     context 'when getting replication of an existing topic' do
-      before { get "topics/replication/#{topic}" }
+      before { get "topics/#{topic}/replication" }
 
       it do
         expect(response).to be_ok
@@ -120,7 +120,7 @@ RSpec.describe_current do
     let(:many_partitions_msg) { 'distribution results are computed based only' }
 
     context 'when trying to read distribution of a non-existing topic' do
-      before { get "topics/distribution/#{SecureRandom.uuid}" }
+      before { get "topics/#{SecureRandom.uuid}/distribution" }
 
       it do
         expect(response).not_to be_ok
@@ -129,7 +129,7 @@ RSpec.describe_current do
     end
 
     context 'when getting distribution of an existing empty topic' do
-      before { get "topics/distribution/#{topic}" }
+      before { get "topics/#{topic}/distribution" }
 
       it do
         expect(response).to be_ok
@@ -145,7 +145,7 @@ RSpec.describe_current do
     context 'when getting distribution of an existing empty topic with multiple partitions' do
       let(:partitions) { 100 }
 
-      before { get "topics/distribution/#{topic}" }
+      before { get "topics/#{topic}/distribution" }
 
       it do
         expect(response).to be_ok
@@ -162,7 +162,7 @@ RSpec.describe_current do
     context 'when getting distribution of an existing topic with one partition and data' do
       before do
         produce_many(topic, Array.new(100, ''))
-        get "topics/distribution/#{topic}"
+        get "topics/#{topic}/distribution"
       end
 
       it do
@@ -183,7 +183,7 @@ RSpec.describe_current do
       before do
         5.times { |i| produce_many(topic, Array.new(100, ''), partition: i) }
 
-        get "topics/distribution/#{topic}"
+        get "topics/#{topic}/distribution"
       end
 
       it do
@@ -205,7 +205,7 @@ RSpec.describe_current do
       before do
         100.times { |i| produce_many(topic, Array.new(10, ''), partition: i) }
 
-        get "topics/distribution/#{topic}"
+        get "topics/#{topic}/distribution"
       end
 
       it do
@@ -227,7 +227,7 @@ RSpec.describe_current do
       before do
         100.times { |i| produce_many(topic, Array.new(10, ''), partition: i) }
 
-        get "topics/distribution/#{topic}?page=2"
+        get "topics/#{topic}/distribution?page=2"
       end
 
       it do


### PR DESCRIPTION
Small remarks that came when a user upgraded to RC:

1. topics details routes are not restful
2. all other karafka web UI related data is compressed in ruby and decompressed to preserver space but not commands

this PR addresses both