### PR TITLE
improve charts on many topics

### DIFF
--- a/lib/karafka/web/ui/public/javascripts/charts/types/line.js
+++ b/lib/karafka/web/ui/public/javascripts/charts/types/line.js
@@ -3,6 +3,30 @@ class LineChartsManager {
     this.datasetStateManager = new DatasetStateManager();
   }
 
+  getLegendHeightPercentage(chart) {
+    const chartArea = chart.chartArea;
+    const chartHeight = chart.height;
+    const legendHeight = chartHeight - (chartArea.bottom - chartArea.top);
+    const legendHeightPercentage = (legendHeight / chartHeight) * 100;
+    return Math.round(legendHeightPercentage);
+  }
+
+  afterRenderPlugin() {
+    const self = this
+
+    return {
+      id: 'afterRender',
+      afterRender: function(chart) {
+        var legendHeightPercentage = self.getLegendHeightPercentage(chart);
+        const element = document.getElementById(chart.canvas.id);
+
+        if (legendHeightPercentage > 50 && element.parentElement.style.height == '') {
+          element.parentElement.style.height = '400px'
+        }
+      }
+    }
+  }
+
   refreshAndRender(doc, isRefresh = false) {
     const charts = (isRefresh ? doc : document).querySelectorAll('.chartjs-line');
 
@@ -31,7 +55,8 @@ class LineChartsManager {
           data: value,
           label: key,
           hidden: disabledSets.includes(index),
-          borderWidth: 2.5
+          borderWidth: 2.5,
+          pointHitRadius: 10
         });
       });
 
@@ -47,6 +72,14 @@ class LineChartsManager {
   }
 
   render(handler, labels, data, yPrecision, labelTypeY) {
+    var tooltip_mode = null
+
+    if (data.length > 10) {
+      tooltip_mode = 'point'
+    } else {
+      tooltip_mode = 'x'
+    }
+
     new Chart(handler, {
       type: 'line',
       data: {
@@ -69,10 +102,6 @@ class LineChartsManager {
           intersect: false
         },
         animation: false,
-        animations: {
-          colors: false,
-          x: false
-        },
         transitions: {
           active: {
             animation: {
@@ -101,6 +130,11 @@ class LineChartsManager {
             }
           },
           tooltip: {
+            mode: tooltip_mode,
+            filter: function (tooltipItem, currentIndex, tooltipItems) {
+              // Display at most 10 elements in the legend
+              return currentIndex < 10
+            },
             callbacks: {
               label: function(tooltipItem) {
                 return DataFormattingUtils.formatTooltip(labelTypeY, tooltipItem);
@@ -137,7 +171,8 @@ class LineChartsManager {
           mode: 'index',
           intersect: false,
         }
-      }
+      },
+      plugins: [this.afterRenderPlugin()]
     });
   }
 }


### PR DESCRIPTION
This PR fixes few things:
- makes sure that hover on charts with many topics is context-aware
- displays at most 10 elements in labels on hover
- adds extra 150px for charts with a lot of data

it does not fix things perfectly but it does make them better

close https://github.com/karafka/karafka-web/issues/332
close https://github.com/karafka/karafka-web/issues/331