### PR TITLE
Display assignment status per topic in pro routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.10.3 (Unreleased)
 - **[Feature]** Introduce ability to brand Web UI with environment (Pro).
+- [Enhancement] Provide assignment status in the routing (Pro).
 - [Enhancement] Support schedule cancellation via Web UI.
 - [Enhancement] Rename "probing" to "tracing" to better reflect what this commanding option does.
 - [Fix] Fix not working primary and secondary alert styles.

--- a/lib/karafka/web/pro/ui/views/routing/_consumer_group.erb
+++ b/lib/karafka/web/pro/ui/views/routing/_consumer_group.erb
@@ -10,6 +10,7 @@
           <th>Subscription group</th>
           <th><%== sort_link('Topic', :name) %></th>
           <th>Type</th>
+          <th>Assigned</th>
           <th><%== sort_link(:active?) %></th>
           <th></th>
         </tr>
@@ -21,6 +22,7 @@
               'routing/topic',
               locals: {
                 subscription_group: topic.subscription_group,
+                consumer_group: consumer_group.id,
                 topic: topic
               }
             )

--- a/lib/karafka/web/pro/ui/views/routing/_topic.erb
+++ b/lib/karafka/web/pro/ui/views/routing/_topic.erb
@@ -21,6 +21,16 @@
   </td>
 
   <td>
+    <% assigned = @assigned[consumer_group].include?(topic.name) %>
+
+    <% if assigned %>
+      <%== badge_success assigned %>
+    <% else %>
+      <%== badge_secondary assigned %>
+    <% end %>
+  </td>
+
+  <td>
     <% if topic.active? %>
       <%== badge_success topic.active? %>
     <% else %>

--- a/spec/lib/karafka/web/pro/ui/controllers/routing_controller_spec.rb
+++ b/spec/lib/karafka/web/pro/ui/controllers/routing_controller_spec.rb
@@ -4,17 +4,38 @@ RSpec.describe_current do
   subject(:app) { Karafka::Web::Pro::Ui::App }
 
   describe '#index' do
-    before { get 'routing' }
+    context 'when running against defaults' do
+      before { get 'routing' }
 
-    it do
-      expect(response).to be_ok
-      expect(body).to include(topics_config.consumers.states)
-      expect(body).to include(topics_config.consumers.metrics)
-      expect(body).to include(topics_config.consumers.reports)
-      expect(body).to include(topics_config.errors)
-      expect(body).to include('karafka_web')
-      expect(body).to include(breadcrumbs)
-      expect(body).not_to include(support_message)
+      it do
+        expect(response).to be_ok
+        expect(body).to include(topics_config.consumers.states)
+        expect(body).to include(topics_config.consumers.metrics)
+        expect(body).to include(topics_config.consumers.reports)
+        expect(body).to include(topics_config.errors)
+        expect(body).to include('karafka_web')
+        expect(body).to include(breadcrumbs)
+        expect(body).not_to include(support_message)
+      end
+    end
+
+    context 'when there is no consumers state' do
+      before do
+        allow(Karafka::Web::Ui::Models::ConsumersState).to receive(:current).and_return(false)
+
+        get 'routing'
+      end
+
+      it do
+        expect(response).to be_ok
+        expect(body).to include(topics_config.consumers.states)
+        expect(body).to include(topics_config.consumers.metrics)
+        expect(body).to include(topics_config.consumers.reports)
+        expect(body).to include(topics_config.errors)
+        expect(body).to include('karafka_web')
+        expect(body).to include(breadcrumbs)
+        expect(body).not_to include(support_message)
+      end
     end
 
     context 'when there are states and reports' do

--- a/spec/lib/karafka/web/pro/ui/controllers/routing_controller_spec.rb
+++ b/spec/lib/karafka/web/pro/ui/controllers/routing_controller_spec.rb
@@ -16,6 +16,35 @@ RSpec.describe_current do
       expect(body).to include(breadcrumbs)
       expect(body).not_to include(support_message)
     end
+
+    context 'when there are states and reports' do
+      let(:states_topic) { create_topic }
+      let(:reports_topic) { create_topic }
+
+      before do
+        topics_config.consumers.states = states_topic
+        topics_config.consumers.reports = reports_topic
+
+        report = Fixtures.consumers_reports_json
+        scope = report[:consumer_groups][:example_app6_app][:subscription_groups][:c4ca4238a0b9_0]
+        base = scope[:topics][:default][:partitions]
+
+        5.times { |i| base[i + 1] = base[:'0'].dup.merge(id: i + 1) }
+
+        produce(states_topic, Fixtures.consumers_states_file)
+        produce(reports_topic, report.to_json)
+
+        get 'routing'
+      end
+
+      it do
+        expect(response).to be_ok
+        expect(body).to include(topics_config.errors)
+        expect(body).to include('karafka_web')
+        expect(body).to include(breadcrumbs)
+        expect(body).not_to include(support_message)
+      end
+    end
   end
 
   describe '#show' do


### PR DESCRIPTION
since "active" is a state on a web UI process, it may not reflect the assignment value. This PR fixes that by displaying both.

While assignment is tricky as it is per partition, this gives a general overview and answers the "is anyone consuming this atm at all" question. This was a frequently requested improvement.

close https://github.com/karafka/karafka-web/issues/367

![image](https://github.com/user-attachments/assets/a428f7a5-ca17-4192-8957-c0eb2024e4a7)
