### PR TITLE
Error out when setup is called after web is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.10.5 (Unreleased)
 - [Fix] Allow for using default search matchers in Karafka Web UI topics including Errors.
+- [Enhancement] Error out when `#setup` is called after `#enable!`.
 - [Maintenance] Require `karafka-core` `>= 2.4.8` and `karafka` `>= 2.4.16`.
 
 ## 0.10.4 (2024-11-26)

--- a/lib/karafka/web.rb
+++ b/lib/karafka/web.rb
@@ -30,6 +30,9 @@ module Karafka
       # Sets up the whole configuration
       # @param [Block] block configuration block
       def setup(&block)
+        # You should never reconfigure Web UI after it has been enabled
+        raise Errors::LateSetupError, 'Always call #setup before #enable!' if config.enabled
+
         if Karafka.pro?
           require_relative 'web/pro/loader'
 

--- a/lib/karafka/web/errors.rb
+++ b/lib/karafka/web/errors.rb
@@ -20,6 +20,11 @@ module Karafka
       # configures Karafka
       KarafkaNotInitializedError = Class.new(BaseError)
 
+      # Raised when you try to configure Web UI after it was enabled. It is not allowed because
+      # Karafka Web UI uses the setup values during the enablement and their later change may not
+      # be fully reflected. Always run `#setup` before `#enable!`.
+      LateSetupError = Class.new(BaseError)
+
       # Errors specific to management
       module Management
         # Similar to processing error with the same name, it is raised when a critical

--- a/spec/lib/karafka/web/errors_spec.rb
+++ b/spec/lib/karafka/web/errors_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe_current do
     specify { expect(error).to be < described_class::BaseError }
   end
 
+  describe 'LateSetupError' do
+    subject(:error) { described_class::LateSetupError }
+
+    specify { expect(error).to be < described_class::BaseError }
+  end
+
   context 'when in Processing namespace' do
     describe 'MissingConsumersStateError' do
       subject(:error) { described_class::Processing::MissingConsumersStateError }


### PR DESCRIPTION
close https://github.com/karafka/karafka-web/issues/484

I will add integration spec in karafka because a clean slate is required (not supported in web specs atm)
