### PR TITLE
Make consumer sampler/stats gathering compatible across debian/alpine/wolfi OSes

### DIFF
--- a/lib/karafka/web/tracking/consumers/sampler.rb
+++ b/lib/karafka/web/tracking/consumers/sampler.rb
@@ -293,7 +293,7 @@ module Karafka
           def memory_threads_ps
             @memory_threads_ps = case RUBY_PLATFORM
                                  when /linux/
-                                  page_size = `getconf PAGESIZE`.strip.to_i
+                                  page_size = Karafka::Web::Tracking::Helpers::Sysconf.page_size
                                   Dir.glob('/proc/[0-9]*/status').map do |status_file|
                                     pid = status_file.match(%r{/proc/(\d+)/status})[1]
 
@@ -303,6 +303,7 @@ module Karafka
                                     # Extract RSS from /proc/<pid>/statm (second field)
                                     statm_file = "/proc/#{pid}/statm"
                                     rss_pages = File.read(statm_file).split[1].to_i rescue 0
+                                    # page size is retrieved from Sysconf
                                     rss_kb = (rss_pages * page_size) / 1024
 
                                     [rss_kb, thcount, pid.to_i]

--- a/lib/karafka/web/tracking/helpers/sysconf.rb
+++ b/lib/karafka/web/tracking/helpers/sysconf.rb
@@ -1,0 +1,29 @@
+require 'fiddle'
+require 'fiddle/import'
+
+module Karafka
+  module Web
+    module Tracking
+      # Namespace for tracking related helpers
+      module Helpers
+        module Sysconf
+          extend Fiddle::Importer
+          case RUBY_PLATFORM
+          when /linux/
+            dlload 'libc.so.6'       # Standard C library on Linux
+            SC_PAGESIZE = 30    # _SC_PAGESIZE constant
+          when /darwin/
+            dlload 'libSystem.B.dylib' # Standard C library on macOS
+            SC_PAGESIZE = 29    # _SC_PAGESIZE constant
+          end
+
+          extern 'long sysconf(int)'
+
+          def self.page_size
+            sysconf(SC_PAGESIZE)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, karafka-web doesn't work properly across various container-based OSes (e.g. debian-based images have taken away the `ps` command, ruby distroless-like containers do not necessarily have all the CLI tools available that are invoked in the sampler.rb code such as `ps` and `w`, alpine's `ps` is not equivalent to the `procps` output that is expected by karafka-web).

This PR contains changes to the Tracking::Consumers::Sampler class such that the methods for gathering `memory_size` , `cpu_usage` (or load averages), and memory stats (rss, thcount, pid) are compatible with debian/alpine/wolfi container image OSes. 