### PR TITLE
Promote charts to oss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - **[Feature]** Provide ability to manage topics configuration from the Web UI (Pro).
 - **[Feature]** Provide ability to manage topics partitioning from the Web UI (Pro).
 - **[Feature]** Provide ability to inject custom CSS and JS to adjust the Web UI.
+- [Enhancement] Promote consumers lags statistics chart to OSS.
+- [Enhancement] Promote consumers RSS statistics chart to OSS.
 - [Enhancement] Remove state cache usage that complicated ability to manage topics.
 - [Enhancement] Improve flash messages.
 - [Enhancement] Improve handling of post-submit redirects.
@@ -20,6 +22,7 @@
 - [Change] Remove per-consumer process duplicated details from Subscriptions and Jobs tabs.
 - [Refactor] Make sure all temporary topics have a `it-` prefix in their name.
 - [Refactor] Introduce a `bin/verify_topics_naming` script to ensure proper test topics naming convention.
+- [Fix] Fix incorrect background color in some of the alert notices.
 - [Fix] Support dark mode in error pages.
 - [Fix] Fix incorrect names in some of the tables headers.
 - [Fix] Normalize position of commanding buttons in regards to other UI elements.

--- a/lib/karafka/web/ui/views/dashboard/_feature_pro.erb
+++ b/lib/karafka/web/ui/views/dashboard/_feature_pro.erb
@@ -1,4 +1,4 @@
-<div class="alert alert-info bg-white mt-0 mb-6">
+<div class="alert alert-secondary mt-0 mb-6">
   <%== icon(:info_circle) %>
   <p>
     This feature is available only to <a target="_blank" href="https://karafka.io/#become-pro">Pro</a>

--- a/lib/karafka/web/ui/views/dashboard/index.erb
+++ b/lib/karafka/web/ui/views/dashboard/index.erb
@@ -21,7 +21,7 @@
     <div class="tab-container inline-tabs">
       <%== partial 'shared/tab_nav', locals: { title: 'Consumed', id: 'consumed', active: true } %>
       <%== partial 'shared/tab_nav', locals: { title: 'Batches', id: 'batches' } %>
-      <%== partial 'shared/tab_nav', locals: { title: 'Lags', id: 'lags', disabled: true } %>
+      <%== partial 'shared/tab_nav', locals: { title: 'Lags', id: 'lags', active: true } %>
       <%== partial 'shared/tab_nav', locals: { title: 'Max LSO', id: 'max-lso' } %>
       <%== partial 'shared/tab_nav', locals: { title: 'Pace', id: 'pace' } %>
     </div>
@@ -39,9 +39,7 @@
     </div>
 
     <div id="lags" class="hidden">
-      <%== partial 'dashboard/feature_pro' %>
-      <% data = { enqueued: set.call, busy: set.call }.to_json %>
-      <%== partial 'shared/charts/line', locals: { data: data, id: 'lags', blurred: true } %>
+      <%== partial 'shared/charts/line', locals: { data: @topics_charts.lags_hybrid, id: 'lags' } %>
     </div>
 
     <div id="max-lso" class="hidden">
@@ -58,7 +56,7 @@
   <div class="tab-container-wrapper" id="graphs2">
     <div class="tab-container inline-tabs">
       <%== partial 'shared/tab_nav', locals: { title: 'Utilization', id: 'utilization', active: true } %>
-      <%== partial 'shared/tab_nav', locals: { title: 'RSS', id: 'rss', disabled: true } %>
+      <%== partial 'shared/tab_nav', locals: { title: 'RSS', id: 'rss', active: true } %>
       <%== partial 'shared/tab_nav', locals: { title: 'Concurrency', id: 'concurrency' } %>
       <%== partial 'shared/tab_nav', locals: { title: 'Data transfers', id: 'data-transfers', disabled: true } %>
     </div>
@@ -71,9 +69,8 @@
     </div>
 
     <div id="rss" class="hidden">
-      <%== partial 'dashboard/feature_pro' %>
-      <% data = { rss: set.call(1_050), process_rss: set.call(1_000) }.to_json %>
-      <%== partial 'shared/charts/line', locals: { data: data, id: 'rss', blurred: true } %>
+      <% data = @aggregated_charts.with(:rss, :process_rss) %>
+      <%== partial 'shared/charts/line', locals: { data: data, id: 'rss', label_type_y: 'memory' } %>
     </div>
 
     <div id="concurrency" class="hidden">


### PR DESCRIPTION
This PR promotes RSS and lags charts to OSS.

With the recent advancements in the Pro Web UI, several new features, as part of my "leaking to OSS" benefit I decided to OSS those. They should help users notice memory leaks and lags fast even if those users cannot use Pro.