### PR TITLE
stabilize specs

### DIFF
--- a/spec/support/links_validator.rb
+++ b/spec/support/links_validator.rb
@@ -30,7 +30,8 @@ class LinksValidator
     # Covers both oss and pro. On status since there are so many invalid we exclude all
     'StatusController' => [/.*/],
     # Also deals with invalid state that affects dashboard
-    'RoutingController' => [%r{/dashboard}, %r{/jobs}, %r{/health}]
+    'RoutingController' => [%r{/dashboard}, %r{/jobs}, %r{/health}],
+    'ClusterController' => [%r{/explorer}]
   }.freeze
 
   # There is no point in visiting same urls for different uuids (like topic views). We use those

--- a/spec/support/links_validator.rb
+++ b/spec/support/links_validator.rb
@@ -73,11 +73,11 @@ class LinksValidator
     links = html.css('a[href]').map { |a| a['href'] }
 
     # Filter to only include internal links (not external or anchors)
-    links.select do |link|
-      next if link.start_with?('#', 'http://', 'https://', 'mailto:', 'tel:')
-      next if link.empty?
+    links.delete_if do |link|
+      next true if link.start_with?('#', 'http://', 'https://', 'mailto:', 'tel:')
+      next true if link.empty?
 
-      true
+      false
     end
 
     links.delete_if do |link|
@@ -107,8 +107,6 @@ class LinksValidator
     end
 
     link_key = visit_key(link)
-
-    p @visited_links.count
 
     # Skip if we've already visited this link
     return if @visited_links.include?(link_key)


### PR DESCRIPTION
Improves specs stability by excluding some of the extra link verifications from the routing controller that checks invalid states.

ref https://github.com/karafka/karafka-web/actions/runs/14323063344/job/40143528414