### PR TITLE
expand allowed kafka warnings

### DIFF
--- a/bin/verify_kafka_warnings
+++ b/bin/verify_kafka_warnings
@@ -6,6 +6,10 @@
 allowed_patterns=(
    "Performing controller activation"
    "registered with feature metadata.version"
+   "Replayed TopicRecord for"
+   "Replayed PartitionRecord for"
+   "Previous leader None and previous leader epoch"
+   "Creating new"
 )
 
 # Get all warnings


### PR DESCRIPTION
similar to the karafka repo, those warnings are valid in our specs.