### PR TITLE
fix typo and move upgrade notes to wiki

### DIFF
--- a/lib/karafka/web/ui/controllers/base_controller.rb
+++ b/lib/karafka/web/ui/controllers/base_controller.rb
@@ -22,7 +22,7 @@ module Karafka
 
           self.sortable_attributes = []
 
-          # Detect that the state of the cache has changed and
+          # Detect that the state of the cache has changed
           before do
             cache.clear_if_needed(
               session[:cache_hash],


### PR DESCRIPTION
This PR removes the upgrade notes from changelog and moves them to wiki similar to karafka to have cohesive setup.