### PR TITLE
🌟🗣 grammar glowup of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,31 +4,31 @@
 [![Gem Version](https://badge.fury.io/rb/karafka-web.svg)](http://badge.fury.io/rb/karafka-web)
 [![Join the chat at https://slack.karafka.io](https://raw.githubusercontent.com/karafka/misc/master/slack.svg)](https://slack.karafka.io)
 
-Karafka Web UI is a user interface for the [Karafka framework](https://github.com/karafka/karafka). The Web UI provides a convenient way for developers to monitor and manage their Karafka-based applications, without the need to use the command line or third party software.
+Karafka Web is a user interface for the [Karafka framework](https://github.com/karafka/karafka). The Web UI provides a convenient way for developers to monitor and manage their Karafka-based applications, without the need to use the command line or third party software.
 
 It allows for easy access to various metrics, such as the number of messages consumed, the number of errors, and the number of consumers operating. It also provides a way to view the different Kafka topics, consumers, and groups that are being used by the application.
 
 > [!IMPORTANT]
-> All of Karafka ecosystems components documentation, including the Web UI, can be found [here](https://karafka.io/docs/#web-ui).
+> All of the Karafka ecosystem components' documentation, including the Web UI, can be found [here](https://karafka.io/docs/#web-ui).
 
 ## Getting started
 
-Karafka Web UI documentation is part of the Karafka framework documentation and can be found [here](https://karafka.io/docs).
+The Karafka Web UI documentation is part of the Karafka framework documentation and can be found [here](https://karafka.io/docs).
 
 ![karafka web ui dashboard](https://raw.githubusercontent.com/karafka/misc/master/printscreens/web-ui.png)
 
 ## Karafka Pro Enhanced Web UI
 
-The Enhanced Web UI, aside from all the features from the OSS version, also offers additional features and capabilities not available in the free version, making it a better option for those looking for more robust monitoring and management capabilities for their Karafka applications. Some of the key benefits of the Enhanced Web UI version include the following:
+The Enhanced Web UI, aside from all the features of the OSS version, also offers additional features and capabilities not available in the free version, making it a better option for those looking for more robust monitoring and management capabilities for their Karafka applications. Some of the key benefits of the Enhanced Web UI version include the following:
 
 - Real-time and historical processing and utilization metrics.
-- Real-time topics lag awareness.
-- Enhanced consumers utilization metrics providing much better insights into processes resources utilization.
+- Real-time topic lag awareness.
+- Enhanced consumer utilization metrics providing much better insights into process resource utilization.
 - Consumer process inspection to quickly analyze the state of a given consuming process.
-- Consumer jobs inspection to view currently running jobs on a per-process basis.
-- Health dashboard containing general consumption overview information
-- Data Explorer allowing for viewing and exploring the data produced to Kafka topics. It understands the routing table and can deserialize data before it is displayed.
+- Consumer job inspection to view currently running jobs on a per-process basis.
+- A health dashboard containing general consumption overview information
+- A Data Explorer allowing for viewing and exploring the data produced to Kafka topics. It understands the routing table and can deserialize data before it is displayed.
 - Enhanced error reporting allowing for backtrace inspection and providing multi-partition support.
-- DLQ / Dead insights allowing to navigate through DLQ topics and messages that were dispatched to them.
+- DLQ / Dead insights allowing you to navigate through DLQ topics and messages that were dispatched to them.
 
 Help me provide high-quality open-source software. Please see the Karafka [homepage](https://karafka.io) for more details.


### PR DESCRIPTION
The name of the project appears to be "Karafka Web", but "Karafka Web UI" (without "the") would only make sense grammatically if that is the name of the project.  I would recommend either adding "The" or else dropping "UI" (as I did). Dropping "UI" makes the following use of "The Web UI" not seem so repetetive as it would if it were immediately following "The Karafka Web UI".  Another alternative would be changing the project name to "Karafka Web UI". 


> All of the Karafka ecosystem components' documentation, including the Web UI, can be found [here](https://karafka.io/docs/#web-ui).

It is possible (though not very likely) that I have misunderstood the intention of the original form of this sentence.  My changes reflect an understanding of it saying that the documentation for all components (plural) within the Karafka ecosystem can be found at the given URL. 


In any grammar "correction" (or suggestion of a change) there is a risk of misunderstanding the original intent.  For example, I would need more information on what is meant by "Real-time topics lag awareness" to be 100% certain that my change is right, but I think you likely want to say "Real-time topic lag awareness".  In English adjectives are not normally pluralized, so my reading of this is that "topic" is the adjective describing "lag", and Karafka gives you monitoring tools to detect topic lag in real time.  Since I'm not a Kafka or Karafka user (yet?)  I don't know what topic lag is (and therefore I don't know with 100% certainty that I'm parsing the grammar correctly). But I'm relatively confident that the change I'm proposing is appropriate.  Of course always feel free to correct me if I'm misunderstanding anything.

"the data produced to Kafka topics" is grammatically unconventional. Do you mean "produced by"?  "produced for"? "sent to"? "produced and sent to"?   I wasn't sure how to change that, so I left it as-is, following the principle to "first do no harm".