### PR TITLE
Update yard-lint to fail on convention severity

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -17,7 +17,7 @@ AllValidators:
     - 'test/**/*'
 
   # Exit code behavior (error, warning, convention, never)
-  FailOnSeverity: error
+  FailOnSeverity: convention
 
 # Documentation validators
 Documentation/UndocumentedObjects:


### PR DESCRIPTION
Change FailOnSeverity from error to convention to catch style/convention issues in addition to errors.