### PR TITLE
Extract linting tools to separate Gemfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,14 +156,10 @@ jobs:
   yard-lint:
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: Gemfile.lint
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Remove platform-specific entries for Ruby 4.x
-        run: |
-          ruby -i -ne 'puts $_ unless /^\s*ffi \(.*-.*\)$/' Gemfile.lock
-          ruby -i -ne 'puts $_ unless /^\s*nokogiri \(.*-.*\)$/' Gemfile.lock
-          ruby -i -e 'prev = nil; $<.each { |line| puts line unless line == prev; prev = line }' Gemfile.lock
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@708024e6c902387ab41de36e1669e43b5ee7085e # v1.283.0

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,4 @@ group :test do
   gem 'rack-test'
   gem 'rspec'
   gem 'simplecov'
-  gem 'yard-lint'
 end

--- a/Gemfile.lint
+++ b/Gemfile.lint
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Documentation linting
+gem 'yard-lint'

--- a/Gemfile.lint.lock
+++ b/Gemfile.lint.lock
@@ -1,0 +1,23 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    yard (0.9.38)
+    yard-lint (1.4.0)
+      yard (~> 0.9)
+      zeitwerk (~> 2.6)
+    zeitwerk (2.7.4)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  yard-lint
+
+CHECKSUMS
+  yard (0.9.38) sha256=721fb82afb10532aa49860655f6cc2eaa7130889df291b052e1e6b268283010f
+  yard-lint (1.4.0) sha256=7dd88fbb08fd77cb840bea899d58812817b36d92291b5693dd0eeb3af9f91f0f
+  zeitwerk (2.7.4) sha256=2bef90f356bdafe9a6c2bd32bcd804f83a4f9b8bc27f3600fff051eb3edcec8b
+
+BUNDLED WITH
+  4.0.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,10 +160,6 @@ GEM
       karafka-rdkafka (>= 0.20.0)
       zeitwerk (~> 2.3)
     webrick (1.9.1)
-    yard (0.9.38)
-    yard-lint (1.3.0)
-      yard (~> 0.9)
-      zeitwerk (~> 2.6)
     zeitwerk (2.7.3)
 
 PLATFORMS
@@ -190,7 +186,6 @@ DEPENDENCIES
   rackup (~> 0.2)
   rspec
   simplecov
-  yard-lint
 
 BUNDLED WITH
    2.7.1

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,11 @@
   "extends": [
     "config:recommended"
   ],
+  "includePaths": [
+    "Gemfile",
+    "Gemfile.lint",
+    ".github/workflows/**"
+  ],
   "github-actions": {
     "enabled": true,
     "pinDigests": true


### PR DESCRIPTION
## Summary

- Move `yard-lint` to a separate `Gemfile.lint` to isolate non-execution/linting dependencies
- Update CI to use `BUNDLE_GEMFILE=Gemfile.lint` for the yard-lint job
- Remove platform-specific lockfile cleanup (no longer needed with separate Gemfile)
- Add `Gemfile.lint` to Renovate's `includePaths` for automatic dependency updates

## Test plan

- [ ] Verify yard-lint CI job passes with the separate Gemfile
- [ ] Confirm Renovate detects and tracks `Gemfile.lint`