### PR TITLE
Fix flaky test in topics configs_controller_spec

### DIFF
--- a/spec/lib/karafka/web/pro/ui/controllers/topics/configs_controller_spec.rb
+++ b/spec/lib/karafka/web/pro/ui/controllers/topics/configs_controller_spec.rb
@@ -135,6 +135,7 @@ RSpec.describe_current do
         before do
           test_topic
           put "topics/#{topic_name}/config/#{property_name}", default_params
+          sleep(1)
         end
 
         it "updates config and redirects with success message" do


### PR DESCRIPTION
## Summary
- Add `sleep(1)` after config update in test to allow Kafka time to propagate changes
- Fixes flaky test that was failing intermittently in CI (seed 39945)

## Problem
Kafka config updates via `Karafka::Admin::Configs.alter` are asynchronous. The test was immediately reading back the config value before Kafka had propagated the change, causing a race condition where the test would get the old/default value instead of the updated value.

## Solution
Added `sleep(1)` after the PUT request, consistent with other Kafka operation tests in the codebase (e.g., `distributions_controller_spec.rb`, `pauses_controller_spec.rb`, `commanding_controller_spec.rb`).

## Test plan
- [x] Verified test passes with seed 39945 (previously failing seed)
- [ ] Wait for CI to verify fix works in parallel execution