### PR TITLE
Add .ruby-version to renovate includePaths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,10 @@
     "config:recommended"
   ],
   "includePaths": [
+    ".ruby-version",
     "Gemfile",
     "Gemfile.lint",
+    "karafka-web.gemspec",
     "package.json",
     ".github/workflows/**"
   ],


### PR DESCRIPTION
## Summary
- Add `.ruby-version` to Renovate's `includePaths` configuration

This enables Renovate to track and propose updates for the Ruby version specified in `.ruby-version`.

## Test plan
- Verify renovate.json is valid JSON
- Renovate will pick up the change on next scheduled run