### PR TITLE
Align concurrency tracking with dynamic thread pool scaling (#1014)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Web Changelog
 
 ## 0.11.7 (Unreleased)
+- [Enhancement] Align concurrency tracking with dynamic thread pool scaling. Workers count is now read from `Karafka::Server.workers.size` instead of the static `Karafka::App.config.concurrency`, so the Web UI accurately reflects runtime thread pool changes.
 - [Enhancement] Track `poll_interval` (max.poll.interval.ms) per subscription group alongside `poll_age` to help users monitor how close they are to the polling timeout limit. Consumer schema version bumped to 1.7.0.
 - [Enhancement] Replace token-based CSRF protection (`route_csrf` plugin) with header-based protection using `Sec-Fetch-Site` header (`sec_fetch_site_csrf` plugin). This eliminates the need for CSRF tokens by leveraging browser-enforced headers that cannot be forged from cross-origin requests. Modern browsers automatically include this header, providing simpler and more robust CSRF protection.
 - [Enhancement] Include a short spec file hash in generated test topic names for traceability. Topic names now follow the `it-{hash}-{uuid}` format, making it easy to identify which test file created a given topic in Kafka logs.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,11 @@
 PATH
   remote: .
   specs:
+    karafka (2.5.10)
+      karafka-core (>= 2.5.13, < 2.6.0)
+      karafka-rdkafka (>= 0.26.1)
+      waterdrop (>= 2.8.14, < 3.0.0)
+      zeitwerk (~> 2.3)
     karafka-web (0.11.6)
       erubi (~> 1.4)
       karafka (>= 2.5.10.rc1, < 2.6.0)
@@ -11,7 +16,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    base64 (0.3.0)
     byebug (13.0.0)
       reline (>= 0.6.0)
     concurrent-ruby (1.3.5)
@@ -21,55 +25,22 @@ GEM
     et-orbi (1.4.0)
       tzinfo
     ffi (1.17.2)
-    ffi (1.17.2-aarch64-linux-gnu)
-    ffi (1.17.2-aarch64-linux-musl)
-    ffi (1.17.2-arm-linux-gnu)
-    ffi (1.17.2-arm-linux-musl)
-    ffi (1.17.2-arm64-darwin)
-    ffi (1.17.2-x86-linux-gnu)
-    ffi (1.17.2-x86-linux-musl)
-    ffi (1.17.2-x86_64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
-    ffi (1.17.2-x86_64-linux-musl)
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
     io-console (0.8.2)
     json (2.16.0)
-    karafka (2.5.2)
-      base64 (~> 0.2)
-      karafka-core (>= 2.5.6, < 2.6.0)
-      karafka-rdkafka (>= 0.22.0)
-      waterdrop (>= 2.8.9, < 3.0.0)
-      zeitwerk (~> 2.3)
-    karafka-core (2.5.7)
+    karafka-core (2.5.13)
       karafka-rdkafka (>= 0.20.0)
       logger (>= 1.6.0)
-    karafka-rdkafka (0.23.0)
+    karafka-rdkafka (0.26.1)
       ffi (~> 1.17.1)
       json (> 2.0)
       logger
       mini_portile2 (~> 2.6)
       rake (> 12)
-    karafka-rdkafka (0.23.0-aarch64-linux-gnu)
-      ffi (~> 1.17.1)
-      json (> 2.0)
-      logger
-      mini_portile2 (~> 2.6)
-      rake (> 12)
-    karafka-rdkafka (0.23.0-arm64-darwin)
-      ffi (~> 1.17.1)
-      json (> 2.0)
-      logger
-      mini_portile2 (~> 2.6)
-      rake (> 12)
-    karafka-rdkafka (0.23.0-x86_64-linux-gnu)
-      ffi (~> 1.17.1)
-      json (> 2.0)
-      logger
-      mini_portile2 (~> 2.6)
-      rake (> 12)
-    karafka-rdkafka (0.23.0-x86_64-linux-musl)
+    karafka-rdkafka (0.26.1-x86_64-linux-gnu)
       ffi (~> 1.17.1)
       json (> 2.0)
       logger
@@ -85,21 +56,7 @@ GEM
     nokogiri (1.19.1)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.19.1-aarch64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.19.1-aarch64-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.19.1-arm-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.19.1-arm-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.19.1-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.19.1-x86_64-darwin)
-      racc (~> 1.4)
     nokogiri (1.19.1-x86_64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.19.1-x86_64-linux-musl)
       racc (~> 1.4)
     ostruct (0.6.3)
     prism (1.9.0)
@@ -127,25 +84,16 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     warning (1.5.0)
-    waterdrop (2.8.13)
-      karafka-core (>= 2.4.9, < 3.0.0)
-      karafka-rdkafka (>= 0.20.0)
+    waterdrop (2.9.0)
+      karafka-core (>= 2.5.12, < 3.0.0)
+      karafka-rdkafka (>= 0.24.0)
       zeitwerk (~> 2.3)
     webrick (1.9.1)
     zeitwerk (2.7.3)
 
 PLATFORMS
-  aarch64-linux-gnu
-  aarch64-linux-musl
-  arm-linux-gnu
-  arm-linux-musl
-  arm64-darwin
   ruby
-  x86-linux-gnu
-  x86-linux-musl
-  x86_64-darwin
-  x86_64-linux-gnu
-  x86_64-linux-musl
+  x86_64-linux
 
 DEPENDENCIES
   byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     karafka-web (0.11.6)
       erubi (~> 1.4)
-      karafka (>= 2.5.2, < 2.6.0)
+      karafka (>= 2.5.10.rc1, < 2.6.0)
       karafka-core (>= 2.5.0, < 2.6.0)
       roda (>= 3.100, < 4.0)
       tilt (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,6 @@
 PATH
   remote: .
   specs:
-    karafka (2.5.10)
-      karafka-core (>= 2.5.13, < 2.6.0)
-      karafka-rdkafka (>= 0.26.1)
-      waterdrop (>= 2.8.14, < 3.0.0)
-      zeitwerk (~> 2.3)
     karafka-web (0.11.6)
       erubi (~> 1.4)
       karafka (>= 2.5.10.rc1, < 2.6.0)
@@ -25,12 +20,26 @@ GEM
     et-orbi (1.4.0)
       tzinfo
     ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
     io-console (0.8.2)
     json (2.16.0)
+    karafka (2.5.10.rc1)
+      karafka-core (>= 2.5.13, < 2.6.0)
+      karafka-rdkafka (>= 0.26.1)
+      waterdrop (>= 2.8.14, < 3.0.0)
+      zeitwerk (~> 2.3)
     karafka-core (2.5.13)
       karafka-rdkafka (>= 0.20.0)
       logger (>= 1.6.0)
@@ -40,7 +49,31 @@ GEM
       logger
       mini_portile2 (~> 2.6)
       rake (> 12)
+    karafka-rdkafka (0.26.1-aarch64-linux-gnu)
+      ffi (~> 1.17.1)
+      json (> 2.0)
+      logger
+      mini_portile2 (~> 2.6)
+      rake (> 12)
+    karafka-rdkafka (0.26.1-aarch64-linux-musl)
+      ffi (~> 1.17.1)
+      json (> 2.0)
+      logger
+      mini_portile2 (~> 2.6)
+      rake (> 12)
+    karafka-rdkafka (0.26.1-arm64-darwin)
+      ffi (~> 1.17.1)
+      json (> 2.0)
+      logger
+      mini_portile2 (~> 2.6)
+      rake (> 12)
     karafka-rdkafka (0.26.1-x86_64-linux-gnu)
+      ffi (~> 1.17.1)
+      json (> 2.0)
+      logger
+      mini_portile2 (~> 2.6)
+      rake (> 12)
+    karafka-rdkafka (0.26.1-x86_64-linux-musl)
       ffi (~> 1.17.1)
       json (> 2.0)
       logger
@@ -56,7 +89,21 @@ GEM
     nokogiri (1.19.1)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.19.1-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.1-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.1-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.1-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.1-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.1-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.1-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.1-x86_64-linux-musl)
       racc (~> 1.4)
     ostruct (0.6.3)
     prism (1.9.0)
@@ -92,8 +139,17 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
   ruby
-  x86_64-linux
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   byebug

--- a/karafka-web.gemspec
+++ b/karafka-web.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.licenses = %w[LGPL-3.0-only Commercial]
 
   spec.add_dependency "erubi", "~> 1.4"
-  spec.add_dependency "karafka", ">= 2.5.2", "< 2.6.0"
+  spec.add_dependency "karafka", ">= 2.5.10.rc1", "< 2.6.0"
   spec.add_dependency "karafka-core", ">= 2.5.0", "< 2.6.0"
   spec.add_dependency "roda", ">= 3.100", "< 4.0"
   spec.add_dependency "tilt", "~> 2.0"

--- a/lib/karafka/web/pro/ui/views/explorer/explorer/show.erb
+++ b/lib/karafka/web/pro/ui/views/explorer/explorer/show.erb
@@ -22,7 +22,6 @@
   <% view_title "Message with offset #{@offset} from partition #{@partition_id}" %>
 
   <%
-    republish_path = explorer_messages_path(@message.topic, @message.partition, @message.offset, 'republish')
     surrounding_path = explorer_topics_path(@message.topic, @message.partition, @message.offset, 'surrounding')
   %>
   <div class="col-span-12">

--- a/lib/karafka/web/tracking/consumers/sampler.rb
+++ b/lib/karafka/web/tracking/consumers/sampler.rb
@@ -173,9 +173,9 @@ module Karafka
           end
 
           # @return [Metrics::Jobs] jobs metrics instance
-          # @note Lazy initialization since it depends on started_at and workers
+          # @note Lazy initialization since it depends on started_at
           def jobs_metrics
-            @jobs_metrics ||= Metrics::Jobs.new(@windows, started_at, workers)
+            @jobs_metrics ||= Metrics::Jobs.new(@windows, started_at)
           end
 
           # @return [Integer] memory used by this process in kilobytes
@@ -213,8 +213,9 @@ module Karafka
           end
 
           # @return [Integer] number of threads that process work
+          # @note Not memoized because the thread pool can be dynamically scaled at runtime
           def workers
-            @workers ||= Karafka::App.config.concurrency
+            Karafka::Server.workers.size
           end
 
           # Loads our ps results into memory so we can extract from them whatever we need

--- a/lib/karafka/web/tracking/consumers/sampler/metrics/jobs.rb
+++ b/lib/karafka/web/tracking/consumers/sampler/metrics/jobs.rb
@@ -28,9 +28,14 @@ module Karafka
 
                 timefactor = [float_now - started_at, 60].min
 
+                workers_count = workers
+
+                # If downscaled completely (edge case) we return 0 because no way to compute
+                return 0 if workers_count.zero?
+
                 # We divide by 1_000 to convert from milliseconds
                 # We multiply by 100 to have it in % scale
-                (totals.sum / 1_000 / workers / timefactor * 100).round(2)
+                (totals.sum / 1_000 / workers_count / timefactor * 100).round(2)
               end
 
               # @return [Hash] job queue statistics

--- a/lib/karafka/web/tracking/consumers/sampler/metrics/jobs.rb
+++ b/lib/karafka/web/tracking/consumers/sampler/metrics/jobs.rb
@@ -12,12 +12,10 @@ module Karafka
 
               # @param windows [Helpers::Ttls::Windows] time windows for aggregating metrics
               # @param started_at [Float] process start time
-              # @param workers [Integer] number of worker threads
-              def initialize(windows, started_at, workers)
+              def initialize(windows, started_at)
                 super()
                 @windows = windows
                 @started_at = started_at
-                @workers = workers
               end
 
               # @return [Numeric] % utilization of all the threads. 100% means all the threads are
@@ -50,7 +48,13 @@ module Karafka
 
               private
 
-              attr_reader :windows, :started_at, :workers
+              attr_reader :windows, :started_at
+
+              # @return [Integer] current number of worker threads
+              # @note Not memoized because the thread pool can be dynamically scaled at runtime
+              def workers
+                Karafka::Server.workers.size
+              end
             end
           end
         end

--- a/lib/karafka/web/tracking/consumers/sampler/metrics/server.rb
+++ b/lib/karafka/web/tracking/consumers/sampler/metrics/server.rb
@@ -21,8 +21,9 @@ module Karafka
               end
 
               # @return [Integer] number of threads that process work
+              # @note Not memoized because the thread pool can be dynamically scaled at runtime
               def workers
-                Karafka::App.config.concurrency
+                Karafka::Server.workers.size
               end
             end
           end

--- a/lib/karafka/web/ui/views/consumers/_assignments_badges.erb
+++ b/lib/karafka/web/ui/views/consumers/_assignments_badges.erb
@@ -8,7 +8,6 @@
   <% end %>
 
   <% sg_topics.each do |topic_name, partitions| %>
-    <% partitions_list = partitions.join(', ') %>
     <span
       class="badge badge-secondary"
       title="Consumer group: <%= consumer_group.id %>, assignments: <%= topics_assignment_label(topic_name, partitions, limit: 25) %>"

--- a/test/lib/karafka/web/tracking/consumers/sampler/metrics/jobs_test.rb
+++ b/test/lib/karafka/web/tracking/consumers/sampler/metrics/jobs_test.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 describe Karafka::Web::Tracking::Consumers::Sampler::Metrics::Jobs do
-  let(:jobs_metrics) { described_class.new(windows, started_at, workers) }
+  let(:jobs_metrics) { described_class.new(windows, started_at) }
 
   let(:windows) { Karafka::Web::Tracking::Helpers::Ttls::Windows.new }
   let(:started_at) { Time.now.to_f }
-  let(:workers) { 5 }
+
+  before { Karafka::Server.workers.stubs(:size).returns(5) }
 
   describe "#utilization" do
     context "when there are no processed totals" do

--- a/test/lib/karafka/web/tracking/consumers/sampler/metrics/server_test.rb
+++ b/test/lib/karafka/web/tracking/consumers/sampler/metrics/server_test.rb
@@ -70,7 +70,7 @@ describe Karafka::Web::Tracking::Consumers::Sampler::Metrics::Server do
 
   describe "#workers" do
     before do
-      Karafka::App.config.stubs(:concurrency).returns(10)
+      Karafka::Server.workers.stubs(:size).returns(10)
     end
 
     it "returns configured concurrency" do

--- a/test/lib/karafka/web/tracking/consumers/sampler_test.rb
+++ b/test/lib/karafka/web/tracking/consumers/sampler_test.rb
@@ -17,7 +17,7 @@ describe_current do
     it { assert_includes(process[:id], Socket.gethostname) }
     it { assert_equal("initialized", process[:status]) }
     it { assert_equal({ active: 0, standby: 0 }, process[:listeners]) }
-    it { assert_equal(5, process[:workers]) }
+    it { assert_equal(0, process[:workers]) }
     it { assert_equal(0, process[:memory_usage]) }
     it { assert_equal(0, process[:memory_total_usage]) }
     it { refute_nil(process[:memory_size]) }

--- a/test/lib/karafka/web/tracking/sampler_test.rb
+++ b/test/lib/karafka/web/tracking/sampler_test.rb
@@ -8,7 +8,7 @@ describe_current do
   it { assert_includes(sampler.karafka_web_version, "0.11.") }
   it { assert_includes(sampler.karafka_core_version, "2.5.") }
   it { assert(sampler.rdkafka_version.start_with?("0.2")) }
-  it { assert(sampler.librdkafka_version.start_with?("2.12")) }
-  it { assert(sampler.waterdrop_version.start_with?("2.8")) }
+  it { assert(sampler.librdkafka_version.start_with?("2.")) }
+  it { assert(sampler.waterdrop_version.start_with?("2.")) }
   it { refute_empty(sampler.process_id) }
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -163,6 +163,7 @@ Minitest::Spec.class_eval do
     # We do this because some of the tests extend routing and we do not want them to interfere
     # with each other.
     Karafka::App.routes.clear
+    Karafka::Server.workers = Karafka::Processing::WorkersPool.new
     draw_defaults
     Karafka::Web::Management::Actions::Enable.new.send(:extend_routing)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,6 +45,10 @@ if ENV["SPECS_TYPE"] == "pro"
     def self.token
       ENV.fetch("KARAFKA_PRO_LICENSE_TOKEN")
     end
+
+    def self.version
+      "test"
+    end
   end
 
   Karafka.const_set(:License, mod)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,7 +47,7 @@ if ENV["SPECS_TYPE"] == "pro"
     end
 
     def self.version
-      "test"
+      ENV.fetch("KARAFKA_PRO_LICENSE_VERSION")
     end
   end
 


### PR DESCRIPTION
Read workers count from Karafka::Server.workers.size instead of the static Karafka::App.config.concurrency so the Web UI accurately reflects runtime thread pool changes introduced in Karafka 2.5.10.

close https://github.com/karafka/karafka-web/issues/1014