### PR TITLE
Fix flaky CreateInitialStates test via state visibility wait

### DIFF
--- a/test/lib/karafka/web/management/actions/create_initial_states_test.rb
+++ b/test/lib/karafka/web/management/actions/create_initial_states_test.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 describe_current do
-  let(:create) { described_class.new.call }
+  let(:create) do
+    described_class.new.call
+    # Freshly produced records on newly created topics can be briefly invisible to admin reads
+    # due to broker metadata propagation. `require_ui: false` is used because this test does
+    # not run migrations, so the pre-migration state would fail the UI read check indefinitely.
+    wait_for_state_data(require_ui: false)
+  end
 
   let(:consumers_states_topic) { create_topic }
   let(:consumers_metrics_topic) { create_topic }

--- a/test/lib/karafka/web/pro/ui/controllers/explorer/messages_controller_test.rb
+++ b/test/lib/karafka/web/pro/ui/controllers/explorer/messages_controller_test.rb
@@ -73,7 +73,7 @@ describe_current do
     end
 
     context "when message exists" do
-      let(:republished) { Karafka::Web::Ui::Models::Message.find(target_topic, 0, 0) }
+      let(:republished) { wait_for_message(target_topic, 0, 0) }
       let(:payload) { rand.to_s }
       let(:target_partition) { 0 }
       let(:include_source_headers) { "on" }
@@ -124,7 +124,7 @@ describe_current do
 
       context "when we specify target partition" do
         let(:target_partition) { 1 }
-        let(:republished) { Karafka::Web::Ui::Models::Message.find(target_topic, 1, 0) }
+        let(:republished) { wait_for_message(target_topic, 1, 0) }
         let(:target_topic) { create_topic(partitions: 2) }
 
         before do

--- a/test/support/helpers/topics_manager_helper.rb
+++ b/test/support/helpers/topics_manager_helper.rb
@@ -83,16 +83,24 @@ module TopicsManagerHelper
   # migrated state becomes visible.
   #
   # @param timeout [Numeric] maximum time to wait in seconds
-  def wait_for_state_data(timeout: 10)
+  # @param require_ui [Boolean] whether to also require the UI read path to succeed. Must be
+  #   set to `false` in contexts where only `CreateInitialStates` has run without
+  #   `MigrateStatesData`, since `ConsumersState.current` crashes on the pre-migration
+  #   `schema_version: "0.0.0"` state and would otherwise loop until timeout.
+  def wait_for_state_data(timeout: 10, require_ui: true)
     deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
 
     loop do
-      ui_ready = begin
-        Karafka::Web::Ui::Models::ConsumersState.current &&
-          Karafka::Web::Ui::Models::ConsumersMetrics.current
-      rescue
-        false
-      end
+      ui_ready = if require_ui
+                   begin
+                     Karafka::Web::Ui::Models::ConsumersState.current &&
+                       Karafka::Web::Ui::Models::ConsumersMetrics.current
+                   rescue
+                     false
+                   end
+                 else
+                   true
+                 end
 
       processing_ready = begin
         Karafka::Web::Processing::Consumers::State.current!

--- a/test/support/helpers/topics_manager_helper.rb
+++ b/test/support/helpers/topics_manager_helper.rb
@@ -92,15 +92,15 @@ module TopicsManagerHelper
 
     loop do
       ui_ready = if require_ui
-                   begin
-                     Karafka::Web::Ui::Models::ConsumersState.current &&
-                       Karafka::Web::Ui::Models::ConsumersMetrics.current
-                   rescue
-                     false
-                   end
-                 else
-                   true
-                 end
+        begin
+          Karafka::Web::Ui::Models::ConsumersState.current &&
+            Karafka::Web::Ui::Models::ConsumersMetrics.current
+        rescue
+          false
+        end
+      else
+        true
+      end
 
       processing_ready = begin
         Karafka::Web::Processing::Consumers::State.current!

--- a/test/support/helpers/topics_manager_helper.rb
+++ b/test/support/helpers/topics_manager_helper.rb
@@ -120,6 +120,31 @@ module TopicsManagerHelper
     end
   end
 
+  # Polls `Karafka::Web::Ui::Models::Message.find` until the message becomes visible to admin
+  # reads or the timeout elapses. This compensates for the small window between a sync produce
+  # to a freshly created topic and the moment the message is visible to a fresh consumer
+  # (admin read), caused by broker metadata propagation. Without this, tests that produce to a
+  # topic and immediately read it back via the UI model can intermittently raise
+  # `Karafka::Web::Errors::Ui::NotFoundError`.
+  #
+  # @param topic [String] topic name
+  # @param partition [Integer] partition id
+  # @param offset [Integer] offset to look up
+  # @param timeout [Numeric] maximum time to wait in seconds
+  # @return [Karafka::Messages::Message] the found message
+  def wait_for_message(topic, partition, offset, timeout: 10)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+
+    begin
+      Karafka::Web::Ui::Models::Message.find(topic, partition, offset)
+    rescue Karafka::Web::Errors::Ui::NotFoundError
+      raise if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+      sleep(0.1)
+      retry
+    end
+  end
+
   private
 
   # Short hash (6 chars) derived from the calling test file path for topic name traceability.


### PR DESCRIPTION
The `create_initial_states_test` could intermittently fail with `MissingConsumersMetricsError` because freshly produced records on a newly created topic were not yet visible to the admin read used by `Metrics.current!` / `State.current!`, due to broker metadata propagation.

Extend `wait_for_state_data` with a `require_ui:` kwarg (default `true`, preserving existing callsites) so it can be used in contexts that only run `CreateInitialStates` without `MigrateStatesData`. The UI read path would otherwise loop until timeout against the pre-migration `schema_version: "0.0.0"` state.

Call the helper from the `create` let so all four contexts in the test get the visibility wait after producing.