### PR TITLE
Replace per-partition Admin instances with batch watermark offset query

### DIFF
--- a/lib/karafka/web/pro/ui/controllers/topics/offsets_controller.rb
+++ b/lib/karafka/web/pro/ui/controllers/topics/offsets_controller.rb
@@ -53,8 +53,10 @@ module Karafka
                   @topic.partition_count, @params.current_page
                 )
 
+                all_offsets = Admin.read_watermark_offsets(topic_name => @active_partitions)
+
                 offsets = @active_partitions.map do |partition_id|
-                  part_offsets = Admin.read_watermark_offsets(topic_name, partition_id)
+                  part_offsets = all_offsets.fetch(topic_name).fetch(partition_id)
 
                   {
                     partition_id: partition_id,

--- a/lib/karafka/web/ui/lib/admin.rb
+++ b/lib/karafka/web/ui/lib/admin.rb
@@ -17,8 +17,8 @@ module Karafka
           class << self
             extend Forwardable
 
-            def_delegators ::Karafka::Admin, :read_watermark_offsets, :cluster_info, :topic_info,
-                           :with_consumer
+            def_delegators ::Karafka::Admin,
+                          :read_watermark_offsets, :cluster_info, :topic_info, :with_consumer
 
             # Allows us to read messages from the topic
             #

--- a/lib/karafka/web/ui/lib/admin.rb
+++ b/lib/karafka/web/ui/lib/admin.rb
@@ -18,7 +18,7 @@ module Karafka
             extend Forwardable
 
             def_delegators ::Karafka::Admin,
-                          :read_watermark_offsets, :cluster_info, :topic_info, :with_consumer
+              :read_watermark_offsets, :cluster_info, :topic_info, :with_consumer
 
             # Allows us to read messages from the topic
             #

--- a/lib/karafka/web/ui/lib/admin.rb
+++ b/lib/karafka/web/ui/lib/admin.rb
@@ -17,7 +17,8 @@ module Karafka
           class << self
             extend Forwardable
 
-            def_delegators ::Karafka::Admin, :read_watermark_offsets, :cluster_info, :topic_info
+            def_delegators ::Karafka::Admin, :read_watermark_offsets, :cluster_info, :topic_info,
+                           :with_consumer
 
             # Allows us to read messages from the topic
             #

--- a/lib/karafka/web/ui/models/counters.rb
+++ b/lib/karafka/web/ui/models/counters.rb
@@ -29,23 +29,25 @@ module Karafka
           def estimate_errors_count
             estimated = 0
 
-            MAX_ERROR_PARTITIONS.times do |partition|
-              begin
-                offsets = Lib::Admin.read_watermark_offsets(
-                  ::Karafka::Web.config.topics.errors.name,
-                  partition
-                )
-              # We estimate that way instead of using `#cluster_info` to get the partitions count
-              # inside the errors topic, because it is around 90x faster to query for invalid
-              # partition and get the error, instead of querying for all topics on a big cluster
-              #
-              # Most of the users use one or few error partitions at most, so this is fairly
-              # efficient and not problematic
-              rescue Rdkafka::RdkafkaError => e
-                (e.code == :unknown_partition) ? break : raise
-              end
+            Lib::Admin.with_consumer do |consumer|
+              MAX_ERROR_PARTITIONS.times do |partition|
+                begin
+                  offsets = consumer.query_watermark_offsets(
+                    ::Karafka::Web.config.topics.errors.name,
+                    partition
+                  )
+                # We estimate that way instead of using `#cluster_info` to get the partitions count
+                # inside the errors topic, because it is around 90x faster to query for invalid
+                # partition and get the error, instead of querying for all topics on a big cluster
+                #
+                # Most of the users use one or few error partitions at most, so this is fairly
+                # efficient and not problematic
+                rescue Rdkafka::RdkafkaError => e
+                  (e.code == :unknown_partition) ? break : raise
+                end
 
-              estimated += offsets.last - offsets.first
+                estimated += offsets.last - offsets.first
+              end
             end
 
             estimated

--- a/lib/karafka/web/ui/models/topic.rb
+++ b/lib/karafka/web/ui/models/topic.rb
@@ -57,8 +57,10 @@ module Karafka
           def distribution(partitions)
             sum = 0.0
 
+            all_offsets = Admin.read_watermark_offsets(topic_name => partitions)
+
             counts = partitions.map do |partition_id|
-              offsets = Admin.read_watermark_offsets(topic_name, partition_id)
+              offsets = all_offsets.fetch(topic_name).fetch(partition_id)
               count = offsets.last - offsets.first
 
               sum += count


### PR DESCRIPTION
Each call to Admin.read_watermark_offsets(topic, partition) creates a new consumer, queries one partition, then tears it down. In loops over many partitions this is extremely slow. Use the hash-based batch query format and with_consumer block to eliminate redundant consumer creation.

- Topic#distribution: single batch query instead of N per-partition calls
- OffsetsController#show: same batch approach
- Counters#estimate_errors_count: reuse one consumer via with_consumer block
- Expose with_consumer through Lib::Admin delegator

It's 10x faster than the regular for 20 partitions.