### PR TITLE
Fix replications test stubs for batch watermark offset query

### DIFF
--- a/test/lib/karafka/web/pro/ui/controllers/topics/replications_controller_test.rb
+++ b/test/lib/karafka/web/pro/ui/controllers/topics/replications_controller_test.rb
@@ -182,7 +182,9 @@ describe_current do
         topic_model.stubs(:distribution).returns(distribution_result)
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
-        Karafka::Admin.stubs(:read_watermark_offsets).returns([0, 100])
+        Karafka::Admin.stubs(:read_watermark_offsets).returns(
+          { topic => { 0 => [0, 100], 1 => [0, 100] } }
+        )
         Karafka.env.stubs(:production?).returns(true)
 
         get "topics/#{topic}/replication"
@@ -245,7 +247,9 @@ describe_current do
         topic_model.stubs(:distribution).returns(distribution_result)
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
-        Karafka::Admin.stubs(:read_watermark_offsets).returns([0, 100])
+        Karafka::Admin.stubs(:read_watermark_offsets).returns(
+          { topic => { 0 => [0, 100], 1 => [0, 100] } }
+        )
         Karafka.env.stubs(:production?).returns(true)
         get "topics/#{topic}/replication"
       end
@@ -307,7 +311,9 @@ describe_current do
         topic_model.stubs(:distribution).returns(distribution_result)
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
-        Karafka::Admin.stubs(:read_watermark_offsets).returns([0, 100])
+        Karafka::Admin.stubs(:read_watermark_offsets).returns(
+          { topic => { 0 => [0, 100], 1 => [0, 100] } }
+        )
         get "topics/#{topic}/replication"
       end
 


### PR DESCRIPTION
Commit 597f483 switched OffsetsController to use the batch form of read_watermark_offsets (hash arg → nested hash result) instead of the per-partition form. The replications controller test stubs were not updated to match, so the links validator would get a flat [0, 100] array and crash when the offsets page tried .fetch(topic).fetch(partition) on it.

Update all three stubs to return the nested hash structure that the batch calling convention produces.