### PR TITLE
Fix replications test stubs for batch watermark offset query (#1021)

### DIFF
--- a/test/lib/karafka/web/pro/ui/controllers/topics/replications_controller_test.rb
+++ b/test/lib/karafka/web/pro/ui/controllers/topics/replications_controller_test.rb
@@ -182,9 +182,11 @@ describe_current do
         topic_model.stubs(:distribution).returns(distribution_result)
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
-        Karafka::Admin.stubs(:read_watermark_offsets).returns(
-          { topic => { 0 => [0, 100], 1 => [0, 100] } }
-        )
+        stub_and_passthrough(Karafka::Admin, :read_watermark_offsets)
+        Karafka::Admin
+          .stubs(:read_watermark_offsets)
+          .with(topic => [0, 1])
+          .returns({ topic => { 0 => [0, 100], 1 => [0, 100] } })
         Karafka.env.stubs(:production?).returns(true)
 
         get "topics/#{topic}/replication"
@@ -247,9 +249,11 @@ describe_current do
         topic_model.stubs(:distribution).returns(distribution_result)
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
-        Karafka::Admin.stubs(:read_watermark_offsets).returns(
-          { topic => { 0 => [0, 100], 1 => [0, 100] } }
-        )
+        stub_and_passthrough(Karafka::Admin, :read_watermark_offsets)
+        Karafka::Admin
+          .stubs(:read_watermark_offsets)
+          .with(topic => [0, 1])
+          .returns({ topic => { 0 => [0, 100], 1 => [0, 100] } })
         Karafka.env.stubs(:production?).returns(true)
         get "topics/#{topic}/replication"
       end
@@ -311,9 +315,11 @@ describe_current do
         topic_model.stubs(:distribution).returns(distribution_result)
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
-        Karafka::Admin.stubs(:read_watermark_offsets).returns(
-          { topic => { 0 => [0, 100], 1 => [0, 100] } }
-        )
+        stub_and_passthrough(Karafka::Admin, :read_watermark_offsets)
+        Karafka::Admin
+          .stubs(:read_watermark_offsets)
+          .with(topic => [0, 1])
+          .returns({ topic => { 0 => [0, 100], 1 => [0, 100] } })
         get "topics/#{topic}/replication"
       end
 


### PR DESCRIPTION
Use stub_and_passthrough for read_watermark_offsets so only calls with the test topic's batch arguments are stubbed. Other calls (e.g. from the errors page via WatermarkOffsets.find) pass through to the real implementation, preventing the links validator from getting a 500 when it follows navigation links rendered on the replications page.