### PR TITLE
Lower setup-ruby age gate to 5 days so it is ready for grouped ruby PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,13 @@
       ],
       "groupName": "ruby setup",
       "internalChecksFilter": "strict"
+    },
+    {
+      "description": "Let setup-ruby pass age gate before ruby so it is ready when the group PR is created",
+      "matchPackageNames": [
+        "ruby/setup-ruby"
+      ],
+      "minimumReleaseAge": "5 days"
     }
   ],
   "labels": [
@@ -46,6 +53,9 @@
   ],
   "minimumReleaseAge": "7 days",
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "schedule": [
+      "before 4am on the first day of the month"
+    ]
   }
 }


### PR DESCRIPTION
With strict internal checks, the grouped PR waits until all packages pass their age gate. By giving setup-ruby a 5-day gate (vs 7 for ruby), its update is available by the time ruby's gate opens, ensuring both land in the same PR.