### PR TITLE
Replace sequential watermark calls with batch admin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Web Changelog
 
 ## 0.11.7 (Unreleased)
+- [Enhancement] Replace sequential per-partition `query_watermark_offsets` consumer calls in `Counters#estimate_errors_count` with a single targeted `topic_info` metadata call followed by a batch `read_watermark_offsets` admin call. This eliminates the consumer connection overhead and reduces Kafka roundtrips from up to N+1 sequential calls to 3 regardless of partition count.
 - [Enhancement] Allow for zero value in number of workers to support dynamic scaling of Karafka workers.
 - [Enhancement] Align concurrency tracking with dynamic thread pool scaling. Workers count is now read from `Karafka::Server.workers.size` instead of the static `Karafka::App.config.concurrency`, so the Web UI accurately reflects runtime thread pool changes.
 - [Enhancement] Track `poll_interval` (max.poll.interval.ms) per subscription group alongside `poll_age` to help users monitor how close they are to the polling timeout limit. Consumer schema version bumped to 1.7.0.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
       et-orbi (~> 1.4)
       raabro (~> 1.4)
     io-console (0.8.2)
-    json (2.19.5)
+    json (2.19.7)
     karafka (2.5.10.rc1)
       karafka-core (>= 2.5.13, < 2.6.0)
       karafka-rdkafka (>= 0.26.1)
@@ -165,4 +165,4 @@ DEPENDENCIES
   warning
 
 BUNDLED WITH
-   2.7.1
+  4.0.12

--- a/lib/karafka/web/ui/models/counters.rb
+++ b/lib/karafka/web/ui/models/counters.rb
@@ -44,7 +44,7 @@ module Karafka
             all_offsets = ::Karafka::Admin.read_watermark_offsets(errors_topic => partition_ids)
 
             partition_ids.sum do |partition_id|
-              low, high = all_offsets.dig(errors_topic, partition_id) || [0, 0]
+              low, high = all_offsets.fetch(errors_topic).fetch(partition_id)
               high - low
             end
           end

--- a/lib/karafka/web/ui/models/counters.rb
+++ b/lib/karafka/web/ui/models/counters.rb
@@ -6,11 +6,6 @@ module Karafka
       module Models
         # Represents the top counters bar values on the consumers view
         class Counters < Lib::HashProxy
-          # Max errors partitions we support for estimations
-          MAX_ERROR_PARTITIONS = 100
-
-          private_constant :MAX_ERROR_PARTITIONS
-
           # @param state [Hash]
           def initialize(state)
             super(state[:stats])
@@ -26,31 +21,32 @@ module Karafka
           private
 
           # Estimates the number of errors present in the errors topic.
+          #
+          # Uses a single targeted metadata call to discover partition count followed by one
+          # batch ListOffsets admin call, rather than up to N sequential per-partition
+          # query_watermark_offsets consumer calls. This avoids opening a consumer connection
+          # and eliminates the N sequential Kafka roundtrips.
           def estimate_errors_count
-            estimated = 0
+            errors_topic = ::Karafka::Web.config.topics.errors.name
 
-            Lib::Admin.with_consumer do |consumer|
-              MAX_ERROR_PARTITIONS.times do |partition|
-                begin
-                  offsets = consumer.query_watermark_offsets(
-                    ::Karafka::Web.config.topics.errors.name,
-                    partition
-                  )
-                # We estimate that way instead of using `#cluster_info` to get the partitions count
-                # inside the errors topic, because it is around 90x faster to query for invalid
-                # partition and get the error, instead of querying for all topics on a big cluster
-                #
-                # Most of the users use one or few error partitions at most, so this is fairly
-                # efficient and not problematic
-                rescue Rdkafka::RdkafkaError => e
-                  (e.code == :unknown_partition) ? break : raise
-                end
+            begin
+              info = ::Karafka::Admin.topic_info(errors_topic)
+            rescue Rdkafka::RdkafkaError => e
+              return 0 if e.code == :unknown_topic_or_part
 
-                estimated += offsets.last - offsets.first
-              end
+              raise
             end
 
-            estimated
+            partition_count = info[:partition_count]
+            return 0 if partition_count.zero?
+
+            partition_ids = (0...partition_count).to_a
+            all_offsets = ::Karafka::Admin.read_watermark_offsets(errors_topic => partition_ids)
+
+            partition_ids.sum do |partition_id|
+              low, high = all_offsets.dig(errors_topic, partition_id) || [0, 0]
+              high - low
+            end
           end
         end
       end

--- a/test/lib/karafka/web/ui/models/counters_test.rb
+++ b/test/lib/karafka/web/ui/models/counters_test.rb
@@ -8,8 +8,12 @@ describe_current do
     context "when errors topic does not exist in Kafka" do
       before { Karafka::Web.config.topics.errors.name = generate_topic_name }
 
-      it "expect to return zero" do
+      it "expect to return zero errors and load other stats from state correctly" do
+        assert_equal(0, stats[:errors])
         assert_equal(0, stats.errors)
+        assert_equal(16_351, stats.batches)
+        assert_equal(0, stats.dead)
+        assert_equal(2, stats.processes)
       end
     end
 

--- a/test/lib/karafka/web/ui/models/counters_test.rb
+++ b/test/lib/karafka/web/ui/models/counters_test.rb
@@ -2,19 +2,53 @@
 
 describe_current do
   let(:stats) { described_class.new(state) }
-
   let(:state) { Fixtures.consumers_states_json }
-  let(:errors_topic) { create_topic }
 
-  before { Karafka::Web.config.topics.errors.name = errors_topic }
+  describe "#errors" do
+    context "when errors topic does not exist in Kafka" do
+      before { Karafka::Web.config.topics.errors.name = generate_topic_name }
 
-  context "when errors topic does not exist" do
-    it "expect to have zero errors and loaded other stats" do
-      assert_equal(0, stats[:errors])
-      assert_equal(0, stats.errors)
-      assert_equal(16_351, stats.batches)
-      assert_equal(0, stats.dead)
-      assert_equal(2, stats.processes)
+      it "expect to return zero" do
+        assert_equal(0, stats.errors)
+      end
+    end
+
+    context "when errors topic exists but has no messages" do
+      let(:errors_topic) { create_topic }
+
+      before { Karafka::Web.config.topics.errors.name = errors_topic }
+
+      it "expect to return zero" do
+        assert_equal(0, stats.errors)
+      end
+    end
+
+    context "when errors topic has messages in a single partition" do
+      let(:errors_topic) { create_topic }
+
+      before do
+        Karafka::Web.config.topics.errors.name = errors_topic
+        produce_many(errors_topic, Array.new(5) { SecureRandom.uuid })
+      end
+
+      it "expect to return the correct message count" do
+        assert_equal(5, stats.errors)
+      end
+    end
+
+    context "when errors topic has multiple partitions with messages" do
+      let(:errors_topic) { create_topic(partitions: 3) }
+
+      before do
+        Karafka::Web.config.topics.errors.name = errors_topic
+        produce_many(errors_topic, Array.new(3) { SecureRandom.uuid }, partition: 0)
+        produce_many(errors_topic, Array.new(4) { SecureRandom.uuid }, partition: 1)
+        produce_many(errors_topic, Array.new(2) { SecureRandom.uuid }, partition: 2)
+      end
+
+      it "expect to return the sum across all partitions" do
+        assert_equal(9, stats.errors)
+      end
     end
   end
 

--- a/test/lib/karafka/web/ui/models/counters_test.rb
+++ b/test/lib/karafka/web/ui/models/counters_test.rb
@@ -8,12 +8,8 @@ describe_current do
     context "when errors topic does not exist in Kafka" do
       before { Karafka::Web.config.topics.errors.name = generate_topic_name }
 
-      it "expect to return zero errors and load other stats from state correctly" do
-        assert_equal(0, stats[:errors])
+      it "expect to return zero" do
         assert_equal(0, stats.errors)
-        assert_equal(16_351, stats.batches)
-        assert_equal(0, stats.dead)
-        assert_equal(2, stats.processes)
       end
     end
 
@@ -22,8 +18,12 @@ describe_current do
 
       before { Karafka::Web.config.topics.errors.name = errors_topic }
 
-      it "expect to return zero" do
+      it "expect to return zero errors and load other stats from state correctly" do
+        assert_equal(0, stats[:errors])
         assert_equal(0, stats.errors)
+        assert_equal(16_351, stats.batches)
+        assert_equal(0, stats.dead)
+        assert_equal(2, stats.processes)
       end
     end
 


### PR DESCRIPTION
Previously, estimating the errors count opened a consumer connection and called query_watermark_offsets once per partition (up to 100 times), stopping on :unknown_partition to discover the partition count. This exploited the error as a stop signal to avoid a full cluster_info call, but still required N+1 sequential Kafka roundtrips and a consumer connection per UI page load.

The new approach uses Admin.topic_info (single targeted metadata call for one topic) to get the partition count, then Admin.read_watermark_offsets for a single batched LWM+HWM query. Total: 3 Kafka roundtrips regardless of partition count, no consumer connection required.

close https://github.com/karafka/karafka-web/issues/1064