### PR TITLE
Fix ReplicationsController dashboard 500 in links validator (#1021 re…

### DIFF
--- a/test/lib/karafka/web/pro/ui/controllers/topics/replications_controller_test.rb
+++ b/test/lib/karafka/web/pro/ui/controllers/topics/replications_controller_test.rb
@@ -182,13 +182,6 @@ describe_current do
         topic_model.stubs(:distribution).returns(distribution_result)
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
-        Karafka::Admin.stubs(:read_watermark_offsets) do |*args|
-          args.first.is_a?(Hash) ? args.first.transform_values { |ids| ids.each_with_object({}) { |id, h| h[id] = [0, 0] } } : [0, 0]
-        end
-        Karafka::Admin
-          .stubs(:read_watermark_offsets)
-          .with(topic => [0, 1])
-          .returns({ topic => { 0 => [0, 100], 1 => [0, 100] } })
         Karafka.env.stubs(:production?).returns(true)
 
         get "topics/#{topic}/replication"
@@ -251,13 +244,6 @@ describe_current do
         topic_model.stubs(:distribution).returns(distribution_result)
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
-        Karafka::Admin.stubs(:read_watermark_offsets) do |*args|
-          args.first.is_a?(Hash) ? args.first.transform_values { |ids| ids.each_with_object({}) { |id, h| h[id] = [0, 0] } } : [0, 0]
-        end
-        Karafka::Admin
-          .stubs(:read_watermark_offsets)
-          .with(topic => [0, 1])
-          .returns({ topic => { 0 => [0, 100], 1 => [0, 100] } })
         Karafka.env.stubs(:production?).returns(true)
         get "topics/#{topic}/replication"
       end
@@ -319,13 +305,6 @@ describe_current do
         topic_model.stubs(:distribution).returns(distribution_result)
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
-        Karafka::Admin.stubs(:read_watermark_offsets) do |*args|
-          args.first.is_a?(Hash) ? args.first.transform_values { |ids| ids.each_with_object({}) { |id, h| h[id] = [0, 0] } } : [0, 0]
-        end
-        Karafka::Admin
-          .stubs(:read_watermark_offsets)
-          .with(topic => [0, 1])
-          .returns({ topic => { 0 => [0, 100], 1 => [0, 100] } })
         get "topics/#{topic}/replication"
       end
 

--- a/test/lib/karafka/web/pro/ui/controllers/topics/replications_controller_test.rb
+++ b/test/lib/karafka/web/pro/ui/controllers/topics/replications_controller_test.rb
@@ -182,6 +182,10 @@ describe_current do
         topic_model.stubs(:distribution).returns(distribution_result)
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
+        errors_topic = Karafka::Web.config.topics.errors.name
+        Karafka::Admin.stubs(:read_watermark_offsets).returns([0, 0])
+        Karafka::Admin.stubs(:read_watermark_offsets).with(errors_topic => [0]).returns({ errors_topic => { 0 => [0, 0] } })
+        Karafka::Admin.stubs(:read_watermark_offsets).with(topic => [0, 1]).returns({ topic => { 0 => [0, 100], 1 => [0, 100] } })
         Karafka.env.stubs(:production?).returns(true)
 
         get "topics/#{topic}/replication"
@@ -244,6 +248,10 @@ describe_current do
         topic_model.stubs(:distribution).returns(distribution_result)
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
+        errors_topic = Karafka::Web.config.topics.errors.name
+        Karafka::Admin.stubs(:read_watermark_offsets).returns([0, 0])
+        Karafka::Admin.stubs(:read_watermark_offsets).with(errors_topic => [0]).returns({ errors_topic => { 0 => [0, 0] } })
+        Karafka::Admin.stubs(:read_watermark_offsets).with(topic => [0, 1]).returns({ topic => { 0 => [0, 100], 1 => [0, 100] } })
         Karafka.env.stubs(:production?).returns(true)
         get "topics/#{topic}/replication"
       end
@@ -305,6 +313,10 @@ describe_current do
         topic_model.stubs(:distribution).returns(distribution_result)
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
+        errors_topic = Karafka::Web.config.topics.errors.name
+        Karafka::Admin.stubs(:read_watermark_offsets).returns([0, 0])
+        Karafka::Admin.stubs(:read_watermark_offsets).with(errors_topic => [0]).returns({ errors_topic => { 0 => [0, 0] } })
+        Karafka::Admin.stubs(:read_watermark_offsets).with(topic => [0, 1]).returns({ topic => { 0 => [0, 100], 1 => [0, 100] } })
         get "topics/#{topic}/replication"
       end
 

--- a/test/lib/karafka/web/pro/ui/controllers/topics/replications_controller_test.rb
+++ b/test/lib/karafka/web/pro/ui/controllers/topics/replications_controller_test.rb
@@ -183,7 +183,7 @@ describe_current do
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
         Karafka::Admin.stubs(:read_watermark_offsets) do |*args|
-          args.first.is_a?(Hash) ? args.first.transform_values { |ids| ids.index_with { [0, 0] } } : [0, 0]
+          args.first.is_a?(Hash) ? args.first.transform_values { |ids| ids.each_with_object({}) { |id, h| h[id] = [0, 0] } } : [0, 0]
         end
         Karafka::Admin
           .stubs(:read_watermark_offsets)
@@ -252,7 +252,7 @@ describe_current do
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
         Karafka::Admin.stubs(:read_watermark_offsets) do |*args|
-          args.first.is_a?(Hash) ? args.first.transform_values { |ids| ids.index_with { [0, 0] } } : [0, 0]
+          args.first.is_a?(Hash) ? args.first.transform_values { |ids| ids.each_with_object({}) { |id, h| h[id] = [0, 0] } } : [0, 0]
         end
         Karafka::Admin
           .stubs(:read_watermark_offsets)
@@ -320,7 +320,7 @@ describe_current do
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
         Karafka::Admin.stubs(:read_watermark_offsets) do |*args|
-          args.first.is_a?(Hash) ? args.first.transform_values { |ids| ids.index_with { [0, 0] } } : [0, 0]
+          args.first.is_a?(Hash) ? args.first.transform_values { |ids| ids.each_with_object({}) { |id, h| h[id] = [0, 0] } } : [0, 0]
         end
         Karafka::Admin
           .stubs(:read_watermark_offsets)

--- a/test/lib/karafka/web/pro/ui/controllers/topics/replications_controller_test.rb
+++ b/test/lib/karafka/web/pro/ui/controllers/topics/replications_controller_test.rb
@@ -182,7 +182,9 @@ describe_current do
         topic_model.stubs(:distribution).returns(distribution_result)
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
-        Karafka::Admin.stubs(:read_watermark_offsets).returns([0, 0])
+        Karafka::Admin.stubs(:read_watermark_offsets) do |*args|
+          args.first.is_a?(Hash) ? args.first.transform_values { |ids| ids.index_with { [0, 0] } } : [0, 0]
+        end
         Karafka::Admin
           .stubs(:read_watermark_offsets)
           .with(topic => [0, 1])
@@ -249,7 +251,9 @@ describe_current do
         topic_model.stubs(:distribution).returns(distribution_result)
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
-        Karafka::Admin.stubs(:read_watermark_offsets).returns([0, 0])
+        Karafka::Admin.stubs(:read_watermark_offsets) do |*args|
+          args.first.is_a?(Hash) ? args.first.transform_values { |ids| ids.index_with { [0, 0] } } : [0, 0]
+        end
         Karafka::Admin
           .stubs(:read_watermark_offsets)
           .with(topic => [0, 1])
@@ -315,7 +319,9 @@ describe_current do
         topic_model.stubs(:distribution).returns(distribution_result)
         stub_and_passthrough(Karafka::Web::Ui::Models::Topic, :find)
         Karafka::Web::Ui::Models::Topic.stubs(:find).with(topic).returns(topic_model)
-        Karafka::Admin.stubs(:read_watermark_offsets).returns([0, 0])
+        Karafka::Admin.stubs(:read_watermark_offsets) do |*args|
+          args.first.is_a?(Hash) ? args.first.transform_values { |ids| ids.index_with { [0, 0] } } : [0, 0]
+        end
         Karafka::Admin
           .stubs(:read_watermark_offsets)
           .with(topic => [0, 1])


### PR DESCRIPTION
…gression)

The blanket `Karafka::Admin.stubs(:read_watermark_offsets).returns([0, 0])` catch-all stub (added in f0f0b4d to fix Ruby 4.0) leaked into the links validator's dashboard visit. `Counters#estimate_errors_count` calls the batch form of `read_watermark_offsets` and expects a hash back; getting `[0, 0]` caused `.fetch(topic_name)` to raise TypeError, rendering a 500.

The failure was order-dependent: the LinksValidator singleton caches visited URLs, so `/dashboard` was only validated once per test run. On Ruby 3.3 the replication test happened to run before any other test that had already cached `/dashboard`, exposing the bug.

Replace the static `[0, 0]` catch-all with a block stub that returns the correct shape for each call form:
- batch form `{ topic => partition_ids }` → `{ topic => { id => [0,0] } }`
- positional form `(topic, partition_id)` → `[0, 0]`

The specific `.with(topic => [0, 1])` stub is still checked first by Mocha and returns real mock data for the replication page itself. The block catch-all also prevents the Ruby 4.0 `Mocha::ExpectationError` escape issue since no unexpected invocation can occur.