### PR TITLE
Accept block in `Web::Producer#__getobj__` to silence Ruby 3.4 warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [Enhancement] Replace token-based CSRF protection (`route_csrf` plugin) with header-based protection using `Sec-Fetch-Site` header (`sec_fetch_site_csrf` plugin). This eliminates the need for CSRF tokens by leveraging browser-enforced headers that cannot be forged from cross-origin requests. Modern browsers automatically include this header, providing simpler and more robust CSRF protection.
 - [Enhancement] Include a short spec file hash in generated test topic names for traceability. Topic names now follow the `it-{hash}-{uuid}` format, making it easy to identify which test file created a given topic in Kafka logs.
 - [Change] Require Roda `>= 3.100` (previously `~> 3.69`).
+- [Fix] Accept (and ignore) a block in `Karafka::Web::Producer#__getobj__` to silence Ruby 3.4's `strict_unused_block` warning emitted via `SimpleDelegator#method_missing` on every delegated producer call.
 - [Fix] Remove `cgi` as no longer needed.
 - [Fix] Exclude `test/` directory from gem releases to reduce package size.
 - [Fix] Update LinksValidator regexes to match the new `it-{hash}-{uuid}` test topic naming format, fixing test-order dependent failures in explorer controller specs.

--- a/lib/karafka/web/producer.rb
+++ b/lib/karafka/web/producer.rb
@@ -27,7 +27,8 @@ module Karafka
 
       # @return [WaterDrop::Producer, WaterDrop::Producer::Variant] the underlying producer
       #   or its low-ack variant
-      def __getobj__
+      # @note accept block to avoid Ruby 3.4's `strict_unused_block` warning from SimpleDelegator.
+      def __getobj__(&)
         unless @initialized
           @delegate_sd_obj = build_producer
           @initialized = true

--- a/test/lib/karafka/web/producer_test.rb
+++ b/test/lib/karafka/web/producer_test.rb
@@ -90,6 +90,21 @@ describe_current do
         producer.__getobj__
       end
     end
+
+    # `SimpleDelegator#method_missing` always passes a block to `__getobj__`.
+    # `SimpleDelegator#__getobj__` implicitly accepts the block via `block_given?` and
+    # `yield`, but our block-ignoring subclass must explicitly accept a block to avoid
+    # Ruby 3.4's `strict_unused_block` warning on every delegated call.
+    it "accepts a block to preserve the SimpleDelegator __getobj__ contract" do
+      params = described_class.instance_method(:__getobj__).parameters
+
+      assert(
+        params.any? { |type, _| type == :block },
+        "Expected __getobj__ to declare a block parameter to avoid " \
+          "`strict_unused_block` warnings from SimpleDelegator#method_missing, " \
+          "got parameters: #{params.inspect}"
+      )
+    end
   end
 
   describe "delegation" do


### PR DESCRIPTION
`SimpleDelegator` inherits `Delegator#method_missing` which always passes a block to `__getobj__` (it yields only when the delegate is unset), but `Karafka::Web::Producer` introduced in 0.11.6 subclasses `SimpleDelegator` and doesn't receive a block (neither explicitly with an `&` arg nor implicitly by yielding to it etc). On Ruby 3.4 this triggers the new `strict_unused_block` warning category on every delegated producer call for any user who enables that warning (e.g. `-W:strict_unused_block` or `Warning[:strict_unused_block] = true`):

  delegate.rb:84: warning: the block passed to
  'Karafka::Web::Producer#__getobj__' defined at
  karafka-web-0.11.6/lib/karafka/web/producer.rb:30 may be ignored

This patch explicitly accepts, and then ignores, the block via an anonymous block parameter to preserve the `SimpleDelegator` contract. The block is never invoked because the wrapper lazy-initializes the delegate on first access.

Note that even though `SimpleDelegator` doesn't _explicitly_ receive a block arg, it contains `block_given?` and `yield`, so that's _implicitly_ accepting a block.

Add a regression test that asserts `__getobj__` declares a block parameter, which is the property that suppresses the warning.