### PR TITLE
Add Warning.process to test helper to turn Ruby warnings into failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Web Changelog
 
 ## 0.11.7 (Unreleased)
+- [Enhancement] Add `Warning.process` block to the test helper to turn Ruby warnings originating from the project code into test failures.
 - [Enhancement] Replace sequential per-partition `query_watermark_offsets` consumer calls in `Counters#estimate_errors_count` with a single targeted `topic_info` metadata call followed by a batch `read_watermark_offsets` admin call. This eliminates the consumer connection overhead and reduces Kafka roundtrips from up to N+1 sequential calls to 3 regardless of partition count.
 - [Enhancement] Allow for zero value in number of workers to support dynamic scaling of Karafka workers.
 - [Enhancement] Align concurrency tracking with dynamic thread pool scaling. Workers count is now read from `Karafka::Server.workers.size` instead of the static `Karafka::App.config.concurrency`, so the Web UI accurately reflects runtime thread pool changes.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require "ostruct"
 require "nokogiri"
 require "singleton"
 require "digest"
+require "warning"
 
 Warning.process do |warning|
   next unless warning.include?(Dir.pwd)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,17 @@ require "nokogiri"
 require "singleton"
 require "digest"
 
+Warning.process do |warning|
+  next unless warning.include?(Dir.pwd)
+  # Allow OpenStruct usage only in tests
+  next if warning.include?("OpenStruct use") && warning.include?("/test/")
+  next if warning.include?("vendor/")
+  next if warning.include?("minitest_locator.rb")
+  next if warning.include?("fixture_file")
+
+  raise "Warning in your code: #{warning}"
+end
+
 # Are we running regular tests or pro tests
 SPECS_TYPE = ENV.fetch("SPECS_TYPE", "default")
 


### PR DESCRIPTION
Aligns karafka-web with karafka: any Ruby warning originating from project code now raises an exception, catching deprecations and other issues early. Warnings from test support files, vendor code, and fixture helpers are explicitly excluded.