### PR TITLE
Add retry backoff loop for docker compose Kafka startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,12 @@ jobs:
 
       - name: Start Kafka with Docker Compose
         run: |
-          docker compose up -d || (sleep 5 && docker compose up -d)
+          for attempt in 1 2 3 4 5; do
+            docker compose up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0


### PR DESCRIPTION
Docker Hub registry occasionally times out on GH Actions infrastructure, causing the single-retry pattern to fail both attempts. Replace with a 5-attempt loop with linear backoff (15s/30s/45s/60s) and a compose down between retries to ensure a clean state on each attempt.