### PR TITLE
Align wrapped comment lines to the line length limit

### DIFF
--- a/lib/karafka/web/config.rb
+++ b/lib/karafka/web/config.rb
@@ -63,8 +63,7 @@ module Karafka
             # We do not need to to store this data for longer than 1 day as this data is only
             # used to materialize the end states
             # On the other hand we do not want to have it really short-living because in case
-            # of a consumer crash, we may want to use this info to catch up and backfill the
-            # state.
+            # of a consumer crash, we may want to use this info to catch up and backfill the state.
             #
             # In case its not consumed because no processes are running, it also usually means
             # there's no data to consume because no karafka servers report

--- a/lib/karafka/web/management/actions/enable.rb
+++ b/lib/karafka/web/management/actions/enable.rb
@@ -70,8 +70,7 @@ module Karafka
                   manual_offset_management true
                   # Start from the most recent data, do not materialize historical states
                   # This prevents us from dealing with cases, where client id would be changed and
-                  # consumer group name would be renamed and we would start consuming all
-                  # historical
+                  # consumer group name would be renamed and we would start consuming all historical
                   initial_offset "latest"
                   # Increase backoff time on errors. Incompatible schema errors are not recoverable
                   # until rolling upgrade completes, so we use a longer max timeout to prevent

--- a/lib/karafka/web/pro/ui/lib/search/runner.rb
+++ b/lib/karafka/web/pro/ui/lib/search/runner.rb
@@ -151,8 +151,7 @@ module Karafka
                 when "offset"
                   offset
                 when "timestamp"
-                  # Kafka timestamp of message is in ms, we need a second precision for
-                  # `Time#at`
+                  # Kafka timestamp of message is in ms, we need a second precision for `Time#at`
                   Time.at(timestamp / 1_000.to_f)
                 else
                   # This should never happen. Contact us if you see this.

--- a/lib/karafka/web/processing/time_series_tracker.rb
+++ b/lib/karafka/web/processing/time_series_tracker.rb
@@ -112,8 +112,7 @@ module Karafka
             times = grouped.values.map(&:first)
 
             # Inject the most recent to always have it in each reporting range
-            # Otherwise for a longer time ranges we would not have the most recent state
-            # available
+            # Otherwise for a longer time ranges we would not have the most recent state available
             times << values.last unless values.empty?
 
             # Keep the most recent state out of many that would come from the same time moment

--- a/lib/karafka/web/tracking/consumers/listeners/tags.rb
+++ b/lib/karafka/web/tracking/consumers/listeners/tags.rb
@@ -53,8 +53,7 @@ module Karafka
               end
             end
 
-            # Tags virtual partitioned consumers and adds extra info if operates in a collapsed
-            # mode
+            # Tags virtual partitioned consumers and adds extra info if operates in a collapsed mode
             #
             # @param consumer [Karafka::BaseConsumer]
             def tag_virtual_partitions(consumer)

--- a/lib/karafka/web/tracking/consumers/sampler/metrics/os.rb
+++ b/lib/karafka/web/tracking/consumers/sampler/metrics/os.rb
@@ -185,8 +185,7 @@ module Karafka
                     [rss_kb, thcount, pid]
                   end
                 # thcount is not available on macos ps
-                # because of that we inject 0 as threads count similar to how
-                # we do on windows
+                # because of that we inject 0 as threads count similar to how we do on windows
                 when /darwin|bsd/
                   shell
                     .call("ps -A -o rss=,pid=")

--- a/lib/karafka/web/ui/lib/hash_proxy.rb
+++ b/lib/karafka/web/ui/lib/hash_proxy.rb
@@ -23,8 +23,7 @@ module Karafka
           def initialize(hash)
             @hash = hash
             # Nodes we already visited in the context of a given attribute lookup
-            # We cache them not to look for them over and over again if they are used more than
-            # once
+            # We cache them not to look for them over and over again if they are used more than once
             @visited = Hash.new { |h, k| h[k] = {} }
             # Methods invocations cache
             @results = {}

--- a/lib/karafka/web/ui/models/message.rb
+++ b/lib/karafka/web/ui/models/message.rb
@@ -65,8 +65,7 @@ module Karafka
               high_offset = watermark_offsets.high
 
               # If we start from offset -1, it means we want first page with the most recent
-              # results. We obtain this page by using the offset based on the high watermark
-              # off
+              # results. We obtain this page by using the offset based on the high watermark off
               start_offset = high_offset - per_page if start_offset == -1
 
               # No previous pages, no data, and no more offsets

--- a/lib/karafka/web/ui/models/recurring_tasks/schedule.rb
+++ b/lib/karafka/web/ui/models/recurring_tasks/schedule.rb
@@ -39,8 +39,7 @@ module Karafka
                 return false unless candidate
 
                 # If the deserializer is not our dedicated recurring tasks deserializer, it means
-                # that routing for recurring tasks was not loaded, so recurring tasks are not
-                # active
+                # that routing for recurring tasks was not loaded, so recurring tasks are not active
                 #
                 # User might have used recurring tasks previously and disabled them, but still may
                 # navigate to them and then we should not show anything because without the

--- a/lib/karafka/web/ui/models/status/checks/base.rb
+++ b/lib/karafka/web/ui/models/status/checks/base.rb
@@ -43,8 +43,7 @@ module Karafka
 
                 # Declares that this check depends on another check.
                 #
-                # When a check has a dependency, it will be halted if the dependency
-                # fails.
+                # When a check has a dependency, it will be halted if the dependency fails.
                 #
                 # @param check_name [Symbol] the name of the check this depends on
                 # @return [Symbol] the dependency name


### PR DESCRIPTION
Join prose comment lines that were split mid-sentence with no reason to stay under the line length limit. Skips license headers, YARD tags, code examples, feature-list bullets, and conceptually separate sentences.