### PR TITLE
Fix dashboard Pending counter omitting waiting jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Web Changelog
 
 ## 1.0.0 (Unreleased)
+- [Fix] Include jobs in the `waiting` state when aggregating the dashboard "Pending" counter. `State#refresh_current_stats` now resets and sums `stats[:waiting]` from incoming consumer reports (previously it was never aggregated and stayed `0`), so `Counters#pending` (`enqueued + waiting`) no longer undercounts jobs sitting in advanced/recurring/scheduled-message schedulers. `:waiting` is now also validated by the `AggregatedStats` contract.
 - [Fix] Add `initialize` to `Status::Context` that defines all instance variables upfront in a consistent order, giving every instance the same Ruby object shape and eliminating the `:performance` shape-variation warning.
 - [Enhancement] Add `Warning.process` block to the test helper to turn Ruby warnings originating from the project code into test failures.
 - [Enhancement] Enable all opt-in Ruby warning categories in the test helper via `Warning.categories` (available since Ruby 3.4), so any new categories added in future Ruby versions are automatically enabled without code changes.

--- a/lib/karafka/web/processing/consumers/aggregators/state.rb
+++ b/lib/karafka/web/processing/consumers/aggregators/state.rb
@@ -128,6 +128,7 @@ module Karafka
 
               stats[:busy] = 0
               stats[:enqueued] = 0
+              stats[:waiting] = 0
               stats[:workers] = 0
               stats[:processes] = 0
               stats[:rss] = 0
@@ -155,6 +156,7 @@ module Karafka
 
                   stats[:busy] += report_stats[:busy]
                   stats[:enqueued] += report_stats[:enqueued]
+                  stats[:waiting] += report_stats[:waiting] || 0
                   stats[:workers] += report_process[:workers] || 0
                   stats[:bytes_received] += report_process[:bytes_received] || 0
                   stats[:bytes_sent] += report_process[:bytes_sent] || 0

--- a/lib/karafka/web/processing/consumers/contracts/aggregated_stats.rb
+++ b/lib/karafka/web/processing/consumers/contracts/aggregated_stats.rb
@@ -18,6 +18,7 @@ module Karafka
             required(:errors) { |val| val.is_a?(Integer) && val >= 0 }
             required(:busy) { |val| val.is_a?(Integer) && val >= 0 }
             required(:enqueued) { |val| val.is_a?(Integer) && val >= 0 }
+            required(:waiting) { |val| val.is_a?(Integer) && val >= 0 }
             required(:workers) { |val| val.is_a?(Integer) && val >= 0 }
             required(:processes) { |val| val.is_a?(Integer) && val >= 0 }
             required(:rss) { |val| val.is_a?(Numeric) && val >= 0 }

--- a/test/lib/karafka/web/processing/consumers/aggregators/state_test.rb
+++ b/test/lib/karafka/web/processing/consumers/aggregators/state_test.rb
@@ -195,6 +195,40 @@ describe_current do
     end
   end
 
+  describe "waiting jobs aggregation" do
+    # Regression coverage for the dashboard "Pending" counter being undercounted.
+    # Counters#pending is `enqueued + waiting`, but the state aggregator never summed
+    # `waiting` from incoming reports, so the materialized state always reported
+    # `stats[:waiting] == 0` and Pending silently ignored jobs sitting in the
+    # scheduler (advanced/recurring/scheduled-message schedulers).
+    def report_with_waiting(waiting:, process_id:)
+      data = Fixtures.consumers_reports_json("multi_partition/v1.4.1_process_1")
+      data[:dispatched_at] = Time.now.to_f
+      data[:process][:id] = process_id
+      data[:stats][:waiting] = waiting
+      data
+    end
+
+    it "sums waiting jobs from a single report into the aggregated stats" do
+      state_aggregator.add(report_with_waiting(waiting: 7, process_id: "process-1"), 42)
+
+      assert_equal(7, state_aggregator.stats[:waiting])
+    end
+
+    it "sums waiting jobs across multiple active reports" do
+      state_aggregator.add(report_with_waiting(waiting: 7, process_id: "process-1"), 42)
+      state_aggregator.add(report_with_waiting(waiting: 5, process_id: "process-2"), 43)
+
+      assert_equal(12, state_aggregator.stats[:waiting])
+    end
+
+    it "resets waiting to zero when reports carry no waiting jobs" do
+      state_aggregator.add(report_with_waiting(waiting: 0, process_id: "process-1"), 42)
+
+      assert_equal(0, state_aggregator.stats[:waiting])
+    end
+  end
+
   describe "#to_h and #stats" do
     it "includes schema version" do
       state = state_aggregator.to_h

--- a/test/lib/karafka/web/processing/consumers/contracts/aggregated_stats_test.rb
+++ b/test/lib/karafka/web/processing/consumers/contracts/aggregated_stats_test.rb
@@ -13,6 +13,7 @@ describe_current do
       errors: 3,
       busy: 4,
       enqueued: 6,
+      waiting: 8,
       workers: 5,
       processes: 2,
       rss: 512.45,
@@ -29,7 +30,7 @@ describe_current do
   end
 
   %i[
-    batches jobs messages retries dead errors busy enqueued workers processes
+    batches jobs messages retries dead errors busy enqueued waiting workers processes
   ].each do |key|
     context "when #{key} is negative" do
       before { stats[key] = -1 }

--- a/test/lib/karafka/web/processing/consumers/contracts/state_test.rb
+++ b/test/lib/karafka/web/processing/consumers/contracts/state_test.rb
@@ -17,6 +17,7 @@ describe_current do
         errors: 3,
         busy: 4,
         enqueued: 6,
+        waiting: 8,
         workers: 5,
         processes: 2,
         rss: 512.45,


### PR DESCRIPTION
State#refresh_current_stats never reset or summed stats[:waiting] from incoming consumer reports, so the materialized state always reported waiting as 0 (it was only ever set, to 0, by the introduce_waiting migration). Counters#pending is `enqueued + waiting`, so the dashboard "Pending" KPI silently undercounted jobs sitting in the scheduler (advanced/recurring/scheduled-message schedulers).

- Reset and sum stats[:waiting] alongside busy/enqueued in the current-stats refresh.
- Add :waiting to the AggregatedStats contract; it is already backfilled by the consumers_states and consumers_metrics introduce_waiting migrations, so existing data stays valid.
- Add regression coverage for single- and multi-report waiting aggregation.