### PR TITLE
Fix dashboard average batch size being floored by integer division

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Web Changelog
 
 ## 1.0.0 (Unreleased)
+- [Fix] Compute the dashboard average batch size with float division so it is no longer floored. `Metrics::Aggregated` divided the per-window message delta by the batch delta using integer division, so e.g. 1000 messages over 47 batches charted as `21` instead of `21.28`, systematically under-reporting the average. It now uses float division rounded to 2 decimals.
 - [Fix] Include jobs in the `waiting` state when aggregating the dashboard "Pending" counter. `State#refresh_current_stats` now resets and sums `stats[:waiting]` from incoming consumer reports (previously it was never aggregated and stayed `0`), so `Counters#pending` (`enqueued + waiting`) no longer undercounts jobs sitting in advanced/recurring/scheduled-message schedulers. `:waiting` is now also validated by the `AggregatedStats` contract.
 - [Fix] Add `initialize` to `Status::Context` that defines all instance variables upfront in a consistent order, giving every instance the same Ruby object shape and eliminating the `:performance` shape-variation warning.
 - [Enhancement] Add `Warning.process` block to the test helper to turn Ruby warnings originating from the project code into test failures.

--- a/lib/karafka/web/ui/models/metrics/aggregated.rb
+++ b/lib/karafka/web/ui/models/metrics/aggregated.rb
@@ -156,7 +156,10 @@ module Karafka
 
                   # We check if not zero just in case something would be off there
                   # We do not want to divide by zero
-                  metrics[:batch_size] = batches.zero? ? 0 : metrics[:messages] / batches
+                  # We use float division and round so the average batch size is not floored
+                  # (both messages and batches are integer deltas, so integer division would
+                  # systematically under-report values like 21.28 as 21)
+                  metrics[:batch_size] = batches.zero? ? 0 : (metrics[:messages].to_f / batches).round(2)
                 end
               end
             end

--- a/test/lib/karafka/web/ui/models/metrics/aggregated_test.rb
+++ b/test/lib/karafka/web/ui/models/metrics/aggregated_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe_current do
+  let(:aggregated) { described_class.new(input) }
+
+  # The drift/gap compensation only touches the :seconds range, so we drive the test through a
+  # :days range with two samples: the second one gets the deltas and the derived batch_size.
+  let(:input) do
+    {
+      seconds: [],
+      days: [
+        [1_000, sample(messages: 0, batches: 0)],
+        [2_000, sample(messages: 1_000, batches: 47)]
+      ]
+    }
+  end
+
+  def sample(messages:, batches:)
+    {
+      jobs: 0, batches: batches, messages: messages,
+      errors: 0, retries: 0, dead: 0, rss: 0, processes: 0
+    }
+  end
+
+  # The enriched batch_size of the most recent (delta-bearing) day sample
+  let(:batch_size) { aggregated[:days].last[1][:batch_size] }
+
+  describe "#batch_size (average messages per batch)" do
+    it "uses float division and rounds to 2 decimals instead of flooring" do
+      # 1000 / 47 => 21.2765..., previously floored to 21
+      assert_in_delta(21.28, batch_size, 0.001)
+    end
+
+    context "when the average is a whole number" do
+      let(:input) do
+        {
+          seconds: [],
+          days: [
+            [1_000, sample(messages: 0, batches: 0)],
+            [2_000, sample(messages: 100, batches: 25)]
+          ]
+        }
+      end
+
+      it "is returned as an exact value" do
+        assert_in_delta(4.0, batch_size, 0.001)
+      end
+    end
+
+    context "when there are no batches in the window" do
+      let(:input) do
+        {
+          seconds: [],
+          days: [
+            [1_000, sample(messages: 0, batches: 0)],
+            [2_000, sample(messages: 5, batches: 0)]
+          ]
+        }
+      end
+
+      it "is zero and does not divide by zero" do
+        assert_equal(0, batch_size)
+      end
+    end
+  end
+end

--- a/test/timings/regular.json
+++ b/test/timings/regular.json
@@ -1,4 +1,5 @@
 {
+  "test/lib/karafka/web/ui/models/metrics/aggregated_test.rb": 3.0,
   "test/lib/karafka/web/ui/models/status_test.rb": 135.926,
   "test/lib/karafka/web/ui/controllers/cluster_controller_test.rb": 125.172,
   "test/lib/karafka/web/ui/controllers/jobs_controller_test.rb": 30.673,


### PR DESCRIPTION
Metrics::Aggregated derived batch_size as messages / batches where both are per-window integer deltas, so Ruby's integer division floored the average: e.g. 1000 messages over 47 batches charted as 21 instead of 21.28, systematically under-reporting it.

Use float division rounded to 2 decimals. The divide-by-zero guard is kept. Adds coverage for the fractional, whole-number and zero-batch cases.