### PR TITLE
Fix array paginator offering a Next link to an empty page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Web Changelog
 
 ## 1.0.0 (Unreleased)
+- [Fix] Stop the array paginator from offering a "Next" link to an empty page when the last page is exactly full. `Paginators::Arrays` decided "is there a next page?" from whether the current page was full, so any list whose total size was an exact multiple of `per_page` (25/50/75/...) surfaced a Next link leading to an empty page. It now reports the last page based on whether a further slice actually exists.
 - [Fix] Compute the dashboard average batch size with float division so it is no longer floored. `Metrics::Aggregated` divided the per-window message delta by the batch delta using integer division, so e.g. 1000 messages over 47 batches charted as `21` instead of `21.28`, systematically under-reporting the average. It now uses float division rounded to 2 decimals.
 - [Fix] Include jobs in the `waiting` state when aggregating the dashboard "Pending" counter. `State#refresh_current_stats` now resets and sums `stats[:waiting]` from incoming consumer reports (previously it was never aggregated and stayed `0`), so `Counters#pending` (`enqueued + waiting`) no longer undercounts jobs sitting in advanced/recurring/scheduled-message schedulers. `:waiting` is now also validated by the `AggregatedStats` contract.
 - [Fix] Add `initialize` to `Status::Context` that defines all instance variables upfront in a consistent order, giving every instance the same Ruby object shape and eliminating the `:performance` shape-variation warning.

--- a/lib/karafka/web/ui/lib/paginations/paginators/arrays.rb
+++ b/lib/karafka/web/ui/lib/paginations/paginators/arrays.rb
@@ -19,7 +19,11 @@ module Karafka
                 def call(array, current_page)
                   slices = array.each_slice(per_page).to_a
                   current_data = slices[current_page - 1] || []
-                  last_page = !(slices.count >= current_page - 1 && current_data.size >= per_page)
+                  # We are on the last page when there is no slice after the current one. The
+                  # previous check keyed off "is the current page full?", which wrongly reported
+                  # a next page whenever the final page was exactly `per_page` long (total size
+                  # an exact multiple of per_page), surfacing a "Next" link to an empty page.
+                  last_page = current_page >= slices.length
 
                   [current_data, last_page]
                 end

--- a/test/lib/karafka/web/ui/lib/paginations/paginators/arrays_test.rb
+++ b/test/lib/karafka/web/ui/lib/paginations/paginators/arrays_test.rb
@@ -42,4 +42,31 @@ describe_current do
     it { assert_equal([], pagination[0]) }
     it { assert(pagination[1]) }
   end
+
+  # Regression: when the total size is an exact multiple of per_page the final page is
+  # exactly full, which previously reported "not last page" and rendered a Next link to an
+  # empty page.
+  context "when the data is an exact multiple of per_page (single full page)" do
+    let(:array) { (0..24).to_a }
+    let(:page) { 1 }
+
+    it { assert_equal((0..24).to_a, pagination[0]) }
+    it { assert(pagination[1]) }
+  end
+
+  context "when the data is an exact multiple of per_page (first of two full pages)" do
+    let(:array) { (0..49).to_a }
+    let(:page) { 1 }
+
+    it { assert_equal((0..24).to_a, pagination[0]) }
+    it { refute(pagination[1]) }
+  end
+
+  context "when the data is an exact multiple of per_page (last of two full pages)" do
+    let(:array) { (0..49).to_a }
+    let(:page) { 2 }
+
+    it { assert_equal((25..49).to_a, pagination[0]) }
+    it { assert(pagination[1]) }
+  end
 end


### PR DESCRIPTION
Paginators::Arrays decided whether a next page exists from whether the current page was full (current_data.size >= per_page). When the total number of items is an exact multiple of per_page, the final page is exactly full, so it was reported as "not the last page" and the UI rendered a "Next" link leading to an empty page (slices[current_page] is nil -> []).

Report the last page based on whether a further slice actually exists (current_page >= slices.length) instead. Backward-compatible with the existing cases; adds regression coverage for exact-multiple totals.