### PR TITLE
Make assert_ok surface the actual exception on a 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Web Changelog
 
 ## 1.0.0 (Unreleased)
+- [Enhancement] Make `assert_ok` surface the actual captured exception (class, message, backtrace) on a 500, not just the generic static error page body. Subscribes to the same `error.occurred` monitor event the production error handler already dispatches web UI errors through, capturing the last one per test. This has been the main blocker in diagnosing rare CI-only flakes in the Pro Explorer controller specs, where a failure only ever showed the generic HTML error page with no indication of what actually broke.
 - [Enhancement] Remove the OSS "support Karafka Pro" banner that was rendered on every Web UI page for non-Pro users. It's no longer needed at this stage since users are already aware of the Pro offering.
 - [Enhancement] Migrate the Web UI topic declarations to Karafka's new standalone `Karafka::App.declaratives.draw` API (Karafka `2.6.0.beta1`). The Web UI topics are declared as `active false` (Web UI manages their creation and runtime replication factor itself), replacing the deprecated routing-based `config(active: false)` bridge that was previously called on each routing topic.
 - [Enhancement] Add `Warning.process` block to the test helper to turn Ruby warnings originating from the project code into test failures.

--- a/test/support/helpers/controller_helper.rb
+++ b/test/support/helpers/controller_helper.rb
@@ -2,6 +2,8 @@
 
 # Extra methods for controller helpers
 module ControllerHelper
+  include Karafka::Web::Tracking::Helpers::ErrorInfo
+
   # @return [String] response body
   def body
     response.body
@@ -67,16 +69,13 @@ module ControllerHelper
   # gives no clue whether a failure is a 404, a 500, or something else, which makes intermittent
   # CI-only failures much harder to diagnose than they need to be.
   #
-  # On a 500, also includes the actual exception (class, message, backtrace) captured via the
-  # `error.occurred` monitor event (see `LastUiError` in test_helper.rb) instead of just the
-  # generic static error page body, which is otherwise the only thing a failure here shows.
+  # On a 500, also includes every actual exception (class, message, trimmed backtrace, and the
+  # Rdkafka error code when applicable) captured via the `error.occurred` monitor event (see
+  # `LastUiError` in test_helper.rb) instead of just the generic static error page body, which is
+  # otherwise the only thing a failure here shows.
   def assert_ok
     message = "Expected a successful response, got #{status}. Body excerpt: #{body[0, 500].inspect}"
-
-    if (error = LastUiError.error)
-      message += "\nCaptured error: #{error.class}: #{error.message}\n" \
-                 "#{Array(error.backtrace).first(15).join("\n")}"
-    end
+    message += captured_errors_report
 
     assert(response.ok?, message)
   end
@@ -94,5 +93,25 @@ module ControllerHelper
   # @return [String] no results on pagination string
   def no_meaningful_results
     "first page to get meaningful results"
+  end
+
+  private
+
+  # @return [String] formatted report of all Web UI errors captured during this test via
+  #   `LastUiError` (empty string if none were captured)
+  def captured_errors_report
+    LastUiError.errors.map { |error| format_captured_error(error) }.join
+  end
+
+  # @param error [StandardError] captured error to format
+  # @return [String] single formatted error report with a trimmed backtrace (app/gem root paths
+  #   stripped, same formatting as what would show up on the Errors UI page for this error)
+  # @note `Rdkafka::RdkafkaError` is deliberately not special-cased here: the production error
+  #   handler already converts it to a 404 before it ever reaches the `error.occurred`
+  #   instrumentation this capture relies on, so it can never actually be one of these.
+  def format_captured_error(error)
+    _klass, message, backtrace = extract_error_info(error)
+
+    "\nCaptured error: #{error.class}: #{message}\n#{backtrace.lines.first(15).join}"
   end
 end

--- a/test/support/helpers/controller_helper.rb
+++ b/test/support/helpers/controller_helper.rb
@@ -66,11 +66,19 @@ module ControllerHelper
   # on failure instead of a bare "Expected false to be truthy". A plain `assert(response.ok?)`
   # gives no clue whether a failure is a 404, a 500, or something else, which makes intermittent
   # CI-only failures much harder to diagnose than they need to be.
+  #
+  # On a 500, also includes the actual exception (class, message, backtrace) captured via the
+  # `error.occurred` monitor event (see `LastUiError` in test_helper.rb) instead of just the
+  # generic static error page body, which is otherwise the only thing a failure here shows.
   def assert_ok
-    assert(
-      response.ok?,
-      "Expected a successful response, got #{status}. Body excerpt: #{body[0, 500].inspect}"
-    )
+    message = "Expected a successful response, got #{status}. Body excerpt: #{body[0, 500].inspect}"
+
+    if (error = LastUiError.error)
+      message += "\nCaptured error: #{error.class}: #{error.message}\n" \
+                 "#{Array(error.backtrace).first(15).join("\n")}"
+    end
+
+    assert(response.ok?, message)
   end
 
   # @return [String] breadcrumbs string part to match for presence

--- a/test/support/helpers/last_ui_error.rb
+++ b/test/support/helpers/last_ui_error.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Captures every Web UI unhandled error instrumented during a test (dispatched via the same
+# `error.occurred` monitor event the production error handler already uses), so `assert_ok`
+# (see `ControllerHelper`) can surface the actual exception(s) on a 500 instead of just a
+# generic HTML body dump. This has been the main blocker in diagnosing rare CI-only flakes in
+# the Explorer controller specs, where the failure only ever showed the static error page body.
+#
+# @note We keep all errors captured during a test, not just the last one, in case more than one
+#   occurs (e.g. a request that triggers an error and a subsequent teardown/link-validation pass
+#   that trips on the resulting page).
+module LastUiError
+  class << self
+    attr_accessor :errors
+
+    def clear
+      self.errors = []
+    end
+  end
+
+  clear
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -275,23 +275,29 @@ Karafka::Web::Management::Actions::MigrateStatesData.new.call
 
 Karafka::Web.enable!
 
-# Captures the most recently instrumented Web UI unhandled error (dispatched via the same
+# Captures every Web UI unhandled error instrumented during a test (dispatched via the same
 # `error.occurred` monitor event the production error handler already uses), so `assert_ok`
-# can surface the actual exception on a 500 instead of just a generic HTML body dump. This has
-# been the main blocker in diagnosing rare CI-only flakes in the Explorer controller specs,
+# can surface the actual exception(s) on a 500 instead of just a generic HTML body dump. This
+# has been the main blocker in diagnosing rare CI-only flakes in the Explorer controller specs,
 # where the failure only ever showed the static error page body.
+#
+# @note We keep all errors captured during a test, not just the last one, in case more than one
+#   occurs (e.g. a request that triggers an error and a subsequent teardown/link-validation pass
+#   that trips on the resulting page).
 module LastUiError
   class << self
-    attr_accessor :error
+    attr_accessor :errors
 
     def clear
-      self.error = nil
+      self.errors = []
     end
   end
+
+  clear
 end
 
 Karafka.monitor.subscribe("error.occurred") do |event|
-  LastUiError.error = event[:error] if event[:type] == "web.ui.error"
+  LastUiError.errors << event[:error] if event[:type] == "web.ui.error"
 end
 
 # Disable CSRF checks for tests

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -200,6 +200,8 @@ Minitest::Spec.class_eval do
 
     Karafka::Web.config.ui.cache.clear
 
+    LastUiError.clear
+
     # Set existing topics
     Karafka::Web.config.topics.consumers.states.name = TOPICS[0]
     Karafka::Web.config.topics.consumers.metrics.name = TOPICS[1]
@@ -272,6 +274,25 @@ produce(TOPICS[3], Fixtures.consumers_commands_file("consumers/current.json"))
 Karafka::Web::Management::Actions::MigrateStatesData.new.call
 
 Karafka::Web.enable!
+
+# Captures the most recently instrumented Web UI unhandled error (dispatched via the same
+# `error.occurred` monitor event the production error handler already uses), so `assert_ok`
+# can surface the actual exception on a 500 instead of just a generic HTML body dump. This has
+# been the main blocker in diagnosing rare CI-only flakes in the Explorer controller specs,
+# where the failure only ever showed the static error page body.
+module LastUiError
+  class << self
+    attr_accessor :error
+
+    def clear
+      self.error = nil
+    end
+  end
+end
+
+Karafka.monitor.subscribe("error.occurred") do |event|
+  LastUiError.error = event[:error] if event[:type] == "web.ui.error"
+end
 
 # Disable CSRF checks for tests
 # Must configure on all classes due to Roda's opts inheritance

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -275,27 +275,9 @@ Karafka::Web::Management::Actions::MigrateStatesData.new.call
 
 Karafka::Web.enable!
 
-# Captures every Web UI unhandled error instrumented during a test (dispatched via the same
-# `error.occurred` monitor event the production error handler already uses), so `assert_ok`
-# can surface the actual exception(s) on a 500 instead of just a generic HTML body dump. This
-# has been the main blocker in diagnosing rare CI-only flakes in the Explorer controller specs,
-# where the failure only ever showed the static error page body.
-#
-# @note We keep all errors captured during a test, not just the last one, in case more than one
-#   occurs (e.g. a request that triggers an error and a subsequent teardown/link-validation pass
-#   that trips on the resulting page).
-module LastUiError
-  class << self
-    attr_accessor :errors
-
-    def clear
-      self.errors = []
-    end
-  end
-
-  clear
-end
-
+# Wires LastUiError (see test/support/helpers/last_ui_error.rb) into the same error.occurred
+# monitor event the production error handler already uses to dispatch Web UI errors, so
+# assert_ok can surface the actual exception on a 500 instead of just a generic HTML body dump.
 Karafka.monitor.subscribe("error.occurred") do |event|
   LastUiError.errors << event[:error] if event[:type] == "web.ui.error"
 end


### PR DESCRIPTION
Rare CI-only flakes in the Pro Explorer controller specs (e.g. the transactional "system entry" spec) have repeatedly failed with nothing more than "got 500" and a generic static error page body, with no indication of what actually broke server-side.

Web UI's error handler already instruments every unhandled error via the error.occurred monitor event before rendering the generic page. Subscribe to that same event in the test helper, capturing the last one per test, and have assert_ok include its class/message/backtrace when a request fails. Next time one of these flakes, the failure output will actually say why.