### PR TITLE
Fix flaky Explorer #export spec via JSON-stable payload

### DIFF
--- a/test/lib/karafka/web/pro/ui/controllers/explorer/messages_controller_test.rb
+++ b/test/lib/karafka/web/pro/ui/controllers/explorer/messages_controller_test.rb
@@ -215,7 +215,12 @@ describe_current do
     end
 
     context "when message exists" do
-      let(:payload) { rand.to_s }
+      # Export deserializes the payload (default JSON deserializer) and re-serializes it with
+      # `#to_json`. A bare numeric payload like `rand.to_s` is not a JSON serialization fixed
+      # point: Ruby's `Float#to_s` and the json gem's float encoder occasionally disagree (e.g.
+      # scientific notation or precision), so `assert_equal(payload, response.body)` was flaky
+      # for roughly 1-in-2000 random values. A JSON string literal round-trips identically.
+      let(:payload) { rand.to_s.to_json }
       let(:expected_file_name) { "#{topic}_0_0_payload.json" }
       let(:expected_disposition) { "attachment; filename=\"#{expected_file_name}\"" }
 


### PR DESCRIPTION
The #export endpoint deserializes the message payload with the default JSON deserializer and re-serializes it via #to_json. The spec used a bare numeric payload (rand.to_s), which is not a JSON serialization fixed point: Ruby's Float#to_s and the json gem's float encoder occasionally disagree on scientific notation or precision, so assert_equal(payload, response.body) failed for roughly 1-in-2000 random values.

Use a JSON string literal payload (rand.to_s.to_json), which round-trips identically through deserialize/serialize.