### PR TITLE
Report forceful shutdown blocking details in the Web UI (#979)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Web Changelog
 
 ## 1.0.1 (Unreleased)
+- [Enhancement] Report the details Karafka publishes on a forceful shutdown (which listeners were still active and which jobs were still in processing, with their blocking status) in the Web UI error details, so a `ForcefulShutdownError` shows what was still blocking (#979).
 - [Enhancement] Show the actual replica and in-sync (ISR) broker ids (not just their counts) in the cluster and topic replication partition views. The leader is emphasized and replicas that have fallen out of sync are highlighted, turning the replication views into an at-a-glance health signal. In Pro, each broker badge links to its broker details page (#1084).
 - [Maintenance] Split the oversized `ApplicationHelper` into focused helper modules (`SortingHelper`, `FormattingHelper`, `BadgesHelper`, `PartitionsHelper`), leaving `ApplicationHelper` with only app/layout/hash utilities.
 

--- a/lib/karafka/web/tracking/consumers/listeners/errors.rb
+++ b/lib/karafka/web/tracking/consumers/listeners/errors.rb
@@ -18,20 +18,11 @@ module Karafka
             #
             # @param event [Karafka::Core::Monitoring::Event]
             def on_error_occurred(event)
-              caller_ref = event[:caller]
-
-              # Collect extra info if it was a consumer related error.
-              # Those come from user code
-              details = case caller_ref
-              when Karafka::BaseConsumer
-                extract_consumer_info(caller_ref)
-              when Karafka::Connection::Client
-                extract_client_info(caller_ref)
-              when Karafka::Connection::Listener
-                extract_listener_info(caller_ref)
-              else
-                {}
-              end
+              # Error details come from two independent sources that we merge together:
+              # - the caller: the user code context in which the error happened
+              # - the error type: extra diagnostics some error types carry in the event payload
+              details = extract_caller_details(event[:caller])
+                .merge(extract_type_details(event))
 
               error_class, error_message, backtrace = extract_error_info(event[:error])
 
@@ -72,6 +63,38 @@ module Karafka
 
             private
 
+            # Collects error details based on who reported the error, that is the user code
+            # context in which it happened (consumer, client or listener).
+            #
+            # @param caller_ref [Object] object that reported the error
+            # @return [Hash] hash with caller specific info for details of error
+            def extract_caller_details(caller_ref)
+              case caller_ref
+              when Karafka::BaseConsumer
+                extract_consumer_info(caller_ref)
+              when Karafka::Connection::Client
+                extract_client_info(caller_ref)
+              when Karafka::Connection::Listener
+                extract_listener_info(caller_ref)
+              else
+                {}
+              end
+            end
+
+            # Collects error details based on the error type. Some error types carry extra
+            # diagnostics in the event payload that do not come from the caller.
+            #
+            # @param event [Karafka::Core::Monitoring::Event]
+            # @return [Hash] hash with type specific info for details of error
+            def extract_type_details(event)
+              case event[:type]
+              when "app.stopping.error"
+                extract_forceful_shutdown_info(event)
+              else
+                {}
+              end
+            end
+
             # @param consumer [::Karafka::BaseConsumer]
             # @return [Hash] hash with consumer specific info for details of error
             def extract_consumer_info(consumer)
@@ -110,6 +133,49 @@ module Karafka
                 subscription_group: listener.subscription_group.id,
                 id: listener.id
               }
+            end
+
+            # Extracts details about what was still blocking when Karafka forcefully terminated.
+            # Karafka publishes the listeners that were still active and the jobs that were still
+            # in the processing pipeline alongside the forceful shutdown error.
+            #
+            # The lists are formatted into readable strings so they render as regular rows in the
+            # generic error details table (same presentation as every other error).
+            #
+            # @param event [Karafka::Core::Monitoring::Event]
+            # @return [Hash] hash with forceful shutdown diagnostics for details of error
+            def extract_forceful_shutdown_info(event)
+              active_listeners = event[:active_listeners] || []
+              alive_workers = event[:alive_workers] || []
+              in_processing = event[:in_processing] || {}
+
+              listeners = active_listeners.map do |listener|
+                "#{listener.id} (#{listener.subscription_group.id})"
+              end
+
+              jobs = in_processing.flat_map do |group_id, group_jobs|
+                group_jobs.map { |job| format_in_processing_job(group_id, job) }
+              end
+
+              # Only include the listener/job lists when there is something to show, so we do not
+              # render empty rows in the error details table
+              details = { alive_workers: alive_workers.size }
+              details[:active_listeners] = listeners.join(", ") unless listeners.empty?
+              details[:in_processing] = jobs.join("; ") unless jobs.empty?
+              details
+            end
+
+            # Formats a single job that was still in processing into a readable description.
+            #
+            # @param group_id [String] subscription group id the job belongs to
+            # @param job [Object] job that was still in the processing pipeline
+            # @return [String] readable job description
+            def format_in_processing_job(group_id, job)
+              status = job.non_blocking? ? "non-blocking" : "blocking"
+              job_type = job.class.name.split("::").last
+
+              "#{job_type} #{job.executor.topic.name}/#{job.executor.partition} " \
+                "(#{group_id}, #{status})"
             end
           end
         end

--- a/test/lib/karafka/web/tracking/consumers/listeners/errors_test.rb
+++ b/test/lib/karafka/web/tracking/consumers/listeners/errors_test.rb
@@ -225,6 +225,97 @@ describe_current do
         assert_equal({}, sampler.errors.last[:details])
       end
     end
+
+    context "when it is a forceful shutdown error" do
+      let(:caller_ref) { Karafka::Server }
+
+      # @param id [String] listener id
+      # @param subscription_group_id [String] subscription group id
+      def build_listener(id, subscription_group_id)
+        stub(id: id, subscription_group: stub(id: subscription_group_id))
+      end
+
+      # The job type is derived from the job class name, so we build classes named like real
+      # processing jobs instead of anonymous mocks (whose names would be meaningless).
+      def build_job(class_name, topic, partition, non_blocking)
+        klass = Class.new do
+          define_method(:non_blocking?) { non_blocking }
+
+          define_method(:executor) do
+            Struct.new(:topic, :partition).new(Struct.new(:name).new(topic), partition)
+          end
+        end
+
+        klass.define_singleton_method(:name) { class_name }
+        klass.new
+      end
+
+      let(:active_listeners) do
+        [
+          build_listener("listener-1", "sub-group-1"),
+          build_listener("listener-2", "sub-group-2")
+        ]
+      end
+
+      let(:in_processing) do
+        {
+          "sub-group-1" => [build_job("Karafka::Processing::Jobs::Consume", "orders", 0, false)],
+          "sub-group-2" => [build_job("Karafka::Processing::Jobs::Shutdown", "payments", 1, true)]
+        }
+      end
+
+      let(:event) do
+        {
+          type: "app.stopping.error",
+          error: error,
+          caller: caller_ref,
+          active_listeners: active_listeners,
+          alive_workers: [Object.new, Object.new],
+          in_processing: in_processing
+        }
+      end
+
+      before { listener.on_error_occurred(event) }
+
+      let(:details) { sampler.errors.last[:details] }
+
+      it "expect to keep the app.stopping.error type" do
+        assert_equal("app.stopping.error", sampler.errors.last[:type])
+      end
+
+      it "expect to report all active listeners by subscription group id, joined" do
+        assert_equal(
+          "listener-1 (sub-group-1), listener-2 (sub-group-2)",
+          details[:active_listeners]
+        )
+      end
+
+      it "expect to report the alive workers count" do
+        assert_equal(2, details[:alive_workers])
+      end
+
+      it "expect to report all in-processing jobs with their blocking status, joined" do
+        assert_equal(
+          "Consume orders/0 (sub-group-1, blocking); " \
+          "Shutdown payments/1 (sub-group-2, non-blocking)",
+          details[:in_processing]
+        )
+      end
+
+      context "when there are no active listeners nor jobs in processing" do
+        let(:active_listeners) { [] }
+        let(:in_processing) { {} }
+
+        it "expect to omit the empty listener and job details" do
+          refute(details.key?(:active_listeners))
+          refute(details.key?(:in_processing))
+        end
+
+        it "expect to still report the alive workers count" do
+          assert_equal(2, details[:alive_workers])
+        end
+      end
+    end
   end
 
   describe "#on_dead_letter_queue_dispatched" do

--- a/test/lib/karafka/web/ui/controllers/errors_controller_test.rb
+++ b/test/lib/karafka/web/ui/controllers/errors_controller_test.rb
@@ -154,6 +154,37 @@ describe_current do
       end
     end
 
+    context "when visiting a forceful shutdown error carrying blocking details" do
+      let(:error_report) do
+        Fixtures.errors_json.merge(
+          type: "app.stopping.error",
+          error_class: "Karafka::Errors::ForcefulShutdownError",
+          details: {
+            alive_workers: 2,
+            active_listeners: "listener-1 (sub-group-1)",
+            in_processing: "Consume orders/0 (sub-group-1, blocking)"
+          }
+        ).to_json
+      end
+
+      before do
+        produce(errors_topic, error_report)
+        get "errors/0"
+      end
+
+      it "expect to render the forceful shutdown blocking details" do
+        assert_ok
+        assert_body("app.stopping.error")
+        assert_body("ForcefulShutdownError")
+        # The details are rendered as regular rows in the generic error details table
+        assert_body("active_listeners")
+        assert_body("listener-1 (sub-group-1)")
+        assert_body("in_processing")
+        assert_body("Consume orders/0 (sub-group-1, blocking)")
+        assert_body("alive_workers")
+      end
+    end
+
     context "when visiting error offset with a transactional record in range" do
       before do
         produce(errors_topic, error_report, partition: 0, type: :transactional)


### PR DESCRIPTION
Karafka publishes what was still blocking when it has to forcefully terminate (active listeners, alive worker count, and jobs still in the processing pipeline with their blocking status) alongside the app.stopping.error event.

Capture that payload into the error details so it shows up in the Web UI error view, formatted as readable rows through the existing generic details table (no presentation changes). Mirrors the field extraction Karafka's own logger listener uses.