### PR TITLE
Keep the most recent record on compacted Web topics for at least a month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Karafka Web Changelog
 
+## Unreleased
+- [Enhancement] Tighten compaction on the `karafka_consumers_states` and `karafka_consumers_metrics` topics (`segment.ms` 1 day -> 6h, add `max.compaction.lag.ms` of 7 days) so superseded versions are collapsed sooner. Values accepted on Apache Kafka, Confluent Cloud, Redpanda and MSK.
+- [Fix] Raise the `retention.ms` floor on the compacted `karafka_consumers_states` and `karafka_consumers_metrics` topics to 1 month (was 1 hour / 1 day) so the most recent record is not deleted on brokers that apply retention to compacted topics (e.g. Redpanda).
+
 ## 1.0.1 (2026-08-24)
 - **[Feature]** Add a generic keyword filtering (search) box to the data-heavy Web UI listings (consumers, controls, jobs, routing, per-process subscriptions, cluster, configs, recurring tasks, the health views and the topic lists), so a specific consumer, topic or job can be found without scrolling. Flat listings also include a field selector to scope the search to a chosen attribute (Pro) (#1073).
 - [Enhancement] Track producer errors from every WaterDrop producer, not only `Karafka.producer` and `Karafka::Web.producer`. Web UI now subscribes its producer error listeners via WaterDrop's class-level (global) monitor, attaching them to each producer as it is configured, so errors from any additional producer a user creates (secondary, transactional, etc.) reach the Web UI. Attaching is idempotent per monitor and skips any listener a user already subscribed themselves, so errors are never counted twice. This also fixes a pre-existing double-counting bug where the default producer's errors were recorded twice, because the old `Karafka.producer == Karafka::Web.producer` guard never matched (the Web producer is a delegator/variant that shares the default producer's monitor), so the same monitor was subscribed twice (#952).

--- a/lib/karafka/web/config.rb
+++ b/lib/karafka/web/config.rb
@@ -77,15 +77,25 @@ module Karafka
           setting :states do
             setting :name, default: "karafka_consumers_states"
 
-            # We care only about the most recent state, previous are irrelevant. So we can
-            # easily compact after one minute. We do not use this beyond the most recent
-            # collective state, hence it all can easily go away. We also limit the segment
-            # size to at most 100MB not to use more space ever.
+            # Single-key compacted topic; only the most recent state matters.
+            #
+            # `retention.ms` is a safety floor. It is inert on Apache Kafka (compact-only topics
+            # are never time-deleted), but brokers that apply retention regardless of cleanup
+            # policy (e.g. Redpanda) would delete the segment holding the last record and empty
+            # the topic. A 1 month floor keeps the last record alive there. We
+            # keep it finite rather than `-1` for portability: some managed brokers reject or
+            # clamp unlimited retention, and on some clouds it is a billing-relevant flag.
             setting :config, default: {
               "cleanup.policy": "compact",
-              "retention.ms": 60 * 60 * 1_000,
-              "segment.ms": 24 * 60 * 60 * 1_000, # 1 day
-              "segment.bytes": 104_857_600 # 100MB
+              "retention.ms": 31 * 24 * 60 * 60 * 1_000, # 1 month, last-record floor
+              # Small so the never-compacted active segment window stays short; clears Confluent
+              # Cloud's 4h minimum.
+              "segment.ms": 6 * 60 * 60 * 1_000, # 6 hours
+              "segment.bytes": 104_857_600, # 100MB
+              # Force-collapse superseded versions on a schedule, not just on dirty-ratio.
+              # Confluent Cloud's Basic/Standard/Enterprise minimum, under the retention floor.
+              # Never removes the latest value for a key.
+              "max.compaction.lag.ms": 7 * 24 * 60 * 60 * 1_000 # 7 days
             }
           end
 
@@ -93,11 +103,13 @@ module Karafka
           setting :metrics do
             setting :name, default: "karafka_consumers_metrics"
 
+            # Single-key compacted topic; same safety-floor reasoning as the states topic above.
             setting :config, default: {
               "cleanup.policy": "compact",
-              "retention.ms": 24 * 60 * 60 * 1_000, # 1 day
-              "segment.ms": 24 * 60 * 60 * 1_000, # 1 day
-              "segment.bytes": 104_857_600 # 100MB
+              "retention.ms": 31 * 24 * 60 * 60 * 1_000, # 1 month, last-record floor
+              "segment.ms": 6 * 60 * 60 * 1_000, # 6 hours
+              "segment.bytes": 104_857_600, # 100MB
+              "max.compaction.lag.ms": 7 * 24 * 60 * 60 * 1_000 # 7 days
             }
           end
 


### PR DESCRIPTION
The states and metrics topics are single-key compacted topics, but they carried a short retention.ms (1 hour and 1 day). Compaction only keeps the latest value per key among records retention has not already deleted, so once the segment holding the only surviving record rolled and aged past retention.ms the segment was deleted and the topic went empty - losing even the most recent record after a long quiet period. Brokers that apply time-based deletion to compacted topics (e.g. Redpanda Cloud) hit this directly.

Raise retention.ms on both topics to a 1 month floor. Compaction keeps them at ~one record, so this costs no meaningful storage but guarantees the most recent record survives at least a month regardless of how the broker treats the cleanup policy.