### PR TITLE
Use Configurable::Injector for Web UI kafka settings (#653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Web Changelog
 
 ## Unreleased
+- [Enhancement] Inject Web UI kafka settings via `Karafka::Web::Config::DefaultsInjector` (built on `Karafka::Core::Configurable::Injector`) so the injection follows the same pattern as Karafka and can be extended by Pro (#653). Requires karafka-core `>= 2.6.3`.
 - [Enhancement] Tighten compaction on the `karafka_consumers_states` and `karafka_consumers_metrics` topics (`segment.ms` 1 day -> 6h, add `max.compaction.lag.ms` of 7 days) so superseded versions are collapsed sooner. Values accepted on Apache Kafka, Confluent Cloud, Redpanda and MSK.
 - [Fix] Raise the `retention.ms` floor on the compacted `karafka_consumers_states` and `karafka_consumers_metrics` topics to 1 month (was 1 hour / 1 day) so the most recent record is not deleted on brokers that apply retention to compacted topics (e.g. Redpanda).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - [Enhancement] Inject Web UI kafka settings via `Karafka::Web::Config::DefaultsInjector` (built on `Karafka::Core::Configurable::Injector`) so the injection follows the same pattern as Karafka and can be extended by Pro (#653). Requires karafka-core `>= 2.6.3`.
+- [Enhancement] Read the Pro commands and scheduled-messages topics through the Web UI admin wrapper so those (transactionally written) reads use the same Web UI kafka settings as the rest of the UI.
 - [Enhancement] Tighten compaction on the `karafka_consumers_states` and `karafka_consumers_metrics` topics (`segment.ms` 1 day -> 6h, add `max.compaction.lag.ms` of 7 days) so superseded versions are collapsed sooner. Values accepted on Apache Kafka, Confluent Cloud, Redpanda and MSK.
 - [Fix] Raise the `retention.ms` floor on the compacted `karafka_consumers_states` and `karafka_consumers_metrics` topics to 1 month (was 1 hour / 1 day) so the most recent record is not deleted on brokers that apply retention to compacted topics (e.g. Redpanda).
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     karafka-web (1.0.1)
       erubi (~> 1.4)
       karafka (>= 2.6.0, < 2.7.0)
-      karafka-core (>= 2.6.2, < 2.7.0)
+      karafka-core (>= 2.6.3, < 2.7.0)
       roda (>= 3.100, < 4.0)
       tilt (~> 2.0)
 
@@ -39,7 +39,7 @@ GEM
       karafka-rdkafka (>= 0.28.0)
       waterdrop (>= 2.10.2, < 3.0.0)
       zeitwerk (~> 2.3)
-    karafka-core (2.6.2)
+    karafka-core (2.6.3)
       karafka-rdkafka (>= 0.20.0)
       logger (>= 1.6.0)
     karafka-rdkafka (0.28.0)

--- a/karafka-web.gemspec
+++ b/karafka-web.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "erubi", "~> 1.4"
   spec.add_dependency "karafka", ">= 2.6.0", "< 2.7.0"
-  spec.add_dependency "karafka-core", ">= 2.6.2", "< 2.7.0"
+  spec.add_dependency "karafka-core", ">= 2.6.3", "< 2.7.0"
   spec.add_dependency "roda", ">= 3.100", "< 4.0"
   spec.add_dependency "tilt", "~> 2.0"
 

--- a/lib/karafka/web/config/defaults_injector.rb
+++ b/lib/karafka/web/config/defaults_injector.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Karafka
+  module Web
+    class Config
+      # Injects Web UI specific kafka settings into a kafka config hash, applying each setting
+      # only when it is not already present in that hash.
+      #
+      # This mirrors `Karafka::Setup::DefaultsInjector`: the values a caller passes explicitly
+      # always win, and the Web UI ones are only filled in for keys the caller did not set. Pro
+      # can layer additional defaults on top by prepending a module onto the singleton class and
+      # calling `super`.
+      #
+      # The defaults come straight from `config.ui.kafka`, so whatever the user configures there
+      # is what gets injected into Web UI admin operations.
+      class DefaultsInjector < Karafka::Core::Configurable::Injector
+        class << self
+          # @return [Hash] Web UI specific kafka settings used as defaults
+          def defaults
+            Karafka::Web.config.ui.kafka
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/web/pro/config/defaults_injector.rb
+++ b/lib/karafka/web/pro/config/defaults_injector.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Karafka Pro - Source Available Commercial Software
+# Copyright (c) 2017-present Maciej Mensfeld. All rights reserved.
+#
+# This software is NOT open source. It is source-available commercial software
+# requiring a paid license for use. It is NOT covered by LGPL.
+#
+# The author retains all right, title, and interest in this software,
+# including all copyrights, patents, and other intellectual property rights.
+# No patent rights are granted under this license.
+#
+# PROHIBITED:
+# - Use without a valid commercial license
+# - Redistribution, modification, or derivative works without authorization
+# - Reverse engineering, decompilation, or disassembly of this software
+# - Use as training data for AI/ML models or inclusion in datasets
+# - Scraping, crawling, or automated collection for any purpose
+#
+# PERMITTED:
+# - Reading, referencing, and linking for personal or commercial use
+# - Runtime retrieval by AI assistants, coding agents, and RAG systems
+#   for the purpose of providing contextual help to Karafka users
+#
+# Receipt, viewing, or possession of this software does not convey or
+# imply any license or right beyond those expressly stated above.
+#
+# License: https://karafka.io/docs/Pro-License-Comm/
+# Contact: contact@karafka.io
+
+module Karafka
+  module Web
+    module Pro
+      module Config
+        # Pro overlay for the Web UI kafka settings injector.
+        #
+        # It is prepended onto `Karafka::Web::Config::DefaultsInjector`'s singleton class when Pro
+        # is loaded, and layers Pro-specific Web UI kafka settings on top of the OSS ones by
+        # calling `super` (the OSS defaults) and merging its own on top. This mirrors how
+        # `Karafka::Pro::Setup::DefaultsInjector` extends `Karafka::Setup::DefaultsInjector`.
+        module DefaultsInjector
+          # Pro-specific Web UI kafka settings layered on top of the OSS defaults.
+          #
+          # Empty for now: Pro does not tune the Web UI admin kafka settings differently from OSS
+          # yet. This is the extension point where such settings would go, so wiring the overlay
+          # now keeps the layering in place for when they are needed.
+          KAFKA_DEFAULTS = {}.freeze
+
+          # @return [Hash] OSS Web UI kafka settings merged with the Pro-specific ones. The Pro
+          #   values win over the OSS ones for any shared key; per-call settings still win over
+          #   both, since the injector only fills in keys the caller did not set.
+          def defaults
+            super.merge(KAFKA_DEFAULTS)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/web/pro/config/defaults_injector.rb
+++ b/lib/karafka/web/pro/config/defaults_injector.rb
@@ -31,6 +31,7 @@
 module Karafka
   module Web
     module Pro
+      # Namespace for Pro configuration components
       module Config
         # Pro overlay for the Web UI kafka settings injector.
         #

--- a/lib/karafka/web/pro/loader.rb
+++ b/lib/karafka/web/pro/loader.rb
@@ -57,6 +57,10 @@ module Karafka
           # @param config [Karafka::Core::Configurable::Node] web config that we can alter with pro
           #   components
           def pre_setup_all(config)
+            # Layer Pro-specific Web UI kafka defaults on top of the OSS ones. Mirrors how
+            # Karafka::Pro::Loader prepends its defaults injector onto the OSS one.
+            Web::Config::DefaultsInjector.singleton_class.prepend(Config::DefaultsInjector)
+
             # Expand the config with commanding configuration
             config.instance_eval do
               setting(:commanding, default: Commanding::Config.config)

--- a/lib/karafka/web/pro/ui/controllers/consumers/commands_controller.rb
+++ b/lib/karafka/web/pro/ui/controllers/consumers/commands_controller.rb
@@ -81,7 +81,9 @@ module Karafka
                 features.commanding!
 
                 # We read 25 just in case there would be a lot of transactional noise
-                messages = ::Karafka::Admin.read_topic(commands_topic, 0, 25)
+                # Uses the Web UI admin wrapper so the commands topic (written transactionally)
+                # is read with the Web UI kafka settings for responsiveness
+                messages = Web::Ui::Lib::Admin.read_topic(commands_topic, 0, 25)
 
                 # We find the most recent (last since they are shipped in reverse order)
                 recent = messages.reverse.find { |message| !message.is_a?(Array) }

--- a/lib/karafka/web/pro/ui/controllers/scheduled_messages/messages_controller.rb
+++ b/lib/karafka/web/pro/ui/controllers/scheduled_messages/messages_controller.rb
@@ -42,7 +42,9 @@ module Karafka
               # @param message_offset [Integer]
               def cancel(topic_id, partition_id, message_offset)
                 # Fetches the message we want to cancel to get its key
-                scheduled_message = Karafka::Admin.read_topic(
+                # Uses the Web UI admin wrapper so this scheduled-messages topic (written
+                # transactionally) is read with the Web UI kafka settings for responsiveness
+                scheduled_message = Web::Ui::Lib::Admin.read_topic(
                   topic_id,
                   partition_id,
                   1,

--- a/lib/karafka/web/ui/lib/admin.rb
+++ b/lib/karafka/web/ui/lib/admin.rb
@@ -37,17 +37,10 @@ module Karafka
                 partition,
                 count,
                 start_offset,
-                # Merge our Web UI specific settings
-                config.merge(settings)
+                # Inject our Web UI specific settings as defaults, letting anything the caller
+                # passes explicitly win over them
+                Config::DefaultsInjector.call(settings.dup)
               )
-            end
-
-            private
-
-            # @return [Hash] kafka config for Web UI interface.
-            # @note It does **not** affect tracking or processing
-            def config
-              ::Karafka::Web.config.ui.kafka
             end
           end
         end

--- a/test/lib/karafka/web/config/defaults_injector_test.rb
+++ b/test/lib/karafka/web/config/defaults_injector_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+describe_current do
+  let(:ui_kafka) { Karafka::Web.config.ui.kafka }
+
+  describe ".defaults" do
+    it "expect to return the Web UI kafka settings" do
+      assert_equal ui_kafka, described_class.defaults
+    end
+  end
+
+  describe ".call" do
+    it "expect to inject the Web UI defaults into an empty settings hash" do
+      assert_equal ui_kafka, described_class.call({})
+    end
+
+    it "expect not to overwrite a setting the caller provided" do
+      key = ui_kafka.keys.first
+
+      result = described_class.call(key => "caller-value")
+
+      assert_equal "caller-value", result[key]
+    end
+
+    it "expect to fill in the defaults the caller did not provide" do
+      result = described_class.call({ "some.extra.setting": 1 })
+
+      ui_kafka.each do |key, value|
+        assert_equal value, result[key]
+      end
+
+      assert_equal 1, result[:"some.extra.setting"]
+    end
+
+    it "expect to return the mutated target hash" do
+      target = {}
+
+      assert_same target, described_class.call(target)
+    end
+
+    it "expect not to mutate the Web UI kafka config" do
+      before = ui_kafka.dup
+
+      described_class.call({ "a.b.c": 1 })
+
+      assert_equal before, ui_kafka
+    end
+  end
+end

--- a/test/lib/karafka/web/pro/config/defaults_injector_test.rb
+++ b/test/lib/karafka/web/pro/config/defaults_injector_test.rb
@@ -1,5 +1,33 @@
 # frozen_string_literal: true
 
+# Karafka Pro - Source Available Commercial Software
+# Copyright (c) 2017-present Maciej Mensfeld. All rights reserved.
+#
+# This software is NOT open source. It is source-available commercial software
+# requiring a paid license for use. It is NOT covered by LGPL.
+#
+# The author retains all right, title, and interest in this software,
+# including all copyrights, patents, and other intellectual property rights.
+# No patent rights are granted under this license.
+#
+# PROHIBITED:
+# - Use without a valid commercial license
+# - Redistribution, modification, or derivative works without authorization
+# - Reverse engineering, decompilation, or disassembly of this software
+# - Use as training data for AI/ML models or inclusion in datasets
+# - Scraping, crawling, or automated collection for any purpose
+#
+# PERMITTED:
+# - Reading, referencing, and linking for personal or commercial use
+# - Runtime retrieval by AI assistants, coding agents, and RAG systems
+#   for the purpose of providing contextual help to Karafka users
+#
+# Receipt, viewing, or possession of this software does not convey or
+# imply any license or right beyond those expressly stated above.
+#
+# License: https://karafka.io/docs/Pro-License-Comm/
+# Contact: contact@karafka.io
+
 describe_current do
   let(:oss_injector) { Karafka::Web::Config::DefaultsInjector }
   let(:ui_kafka) { Karafka::Web.config.ui.kafka }
@@ -15,7 +43,7 @@ describe_current do
   end
 
   describe "layering" do
-    subject(:injector) do
+    let(:injector) do
       base = { "fetch.wait.max.ms": 100, a: 1 }
 
       Class.new(Karafka::Core::Configurable::Injector) do

--- a/test/lib/karafka/web/pro/config/defaults_injector_test.rb
+++ b/test/lib/karafka/web/pro/config/defaults_injector_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+describe_current do
+  let(:oss_injector) { Karafka::Web::Config::DefaultsInjector }
+  let(:ui_kafka) { Karafka::Web.config.ui.kafka }
+
+  it "expect to be prepended onto the OSS Web injector when Pro is enabled" do
+    assert_includes oss_injector.singleton_class.ancestors, described_class
+  end
+
+  it "expect the OSS injector to still expose the Web UI kafka defaults through the overlay" do
+    ui_kafka.each do |key, value|
+      assert_equal value, oss_injector.defaults[key]
+    end
+  end
+
+  describe "layering" do
+    subject(:injector) do
+      base = { "fetch.wait.max.ms": 100, a: 1 }
+
+      Class.new(Karafka::Core::Configurable::Injector) do
+        define_singleton_method(:defaults) { base }
+      end
+    end
+
+    before { injector.singleton_class.prepend(described_class) }
+
+    it "expect to keep the base (super) defaults" do
+      assert_equal 100, injector.defaults[:"fetch.wait.max.ms"]
+      assert_equal 1, injector.defaults[:a]
+    end
+
+    it "expect to merge the Pro defaults on top of the base" do
+      described_class::KAFKA_DEFAULTS.each do |key, value|
+        assert_equal value, injector.defaults[key]
+      end
+    end
+
+    it "expect not to mutate the base defaults when merging" do
+      injector.defaults
+
+      refute_same injector.defaults, described_class::KAFKA_DEFAULTS
+    end
+  end
+end

--- a/test/timings/pro.json
+++ b/test/timings/pro.json
@@ -79,5 +79,6 @@
   "test/lib/karafka/web/pro/commanding/commands/partitions/seek_test.rb": 0.005,
   "test/lib/karafka/web/pro/ui/lib/policies/requests_test.rb": 0.004,
   "test/lib/karafka/web/pro/ui/controllers/support_controller_test.rb": 0.003,
-  "test/lib/karafka/web/pro/commanding/handlers/partitions/commands/pause_test.rb": 0.0
+  "test/lib/karafka/web/pro/commanding/handlers/partitions/commands/pause_test.rb": 0.0,
+  "test/lib/karafka/web/pro/config/defaults_injector_test.rb": 0.01
 }

--- a/test/timings/regular.json
+++ b/test/timings/regular.json
@@ -168,5 +168,6 @@
   "test/lib/karafka/web/tracking/producers/listeners/booting_test.rb": 0.001,
   "test/lib/karafka/web/cli/uninstall_test.rb": 0.001,
   "test/lib/karafka/web/tracking/helpers/ttls/windows_test.rb": 0.0,
-  "test/lib/karafka/web/cli/help_test.rb": 0.0
+  "test/lib/karafka/web/cli/help_test.rb": 0.0,
+  "test/lib/karafka/web/config/defaults_injector_test.rb": 0.01
 }


### PR DESCRIPTION
Introduce Karafka::Web::Config::DefaultsInjector, built on the new Karafka::Core::Configurable::Injector, and use it where the Web UI admin layer applies its kafka settings. This mirrors how Karafka injects its own kafka defaults: caller-provided settings always win, the Web UI ones only fill in the keys the caller did not set, and Pro can layer additional defaults by prepending onto the injector.

Requires karafka-core >= 2.6.3 (bumped in the gemspec).